### PR TITLE
feat: 添加留资表单完整示例

### DIFF
--- a/examples/contact-form/README.md
+++ b/examples/contact-form/README.md
@@ -1,0 +1,74 @@
+# 留资表单示例
+
+完整的留资表单示例，展示如何在自定义页面中收集用户输入并存储到后端表单。
+
+## 文件说明
+
+| 文件 | 说明 |
+|------|------|
+| `fields.json` | 表单字段定义 |
+| `contact-page.js` | 自定义页面源码 |
+| `README.md` | 本文件 |
+
+## 使用步骤
+
+### 1. 创建表单
+
+```bash
+cd ../skills/yida-create-form-page/scripts
+node create-form-page.js create "APP_ID" "留资表单" ../../examples/contact-form/fields.json
+```
+
+记下输出的 `formUuid`，例如 `FORM_ABC123`
+
+### 2. 配置页面代码
+
+编辑 `contact-page.js`，替换：
+
+```javascript
+const formUuid = 'FORM_YOUR_FORM_UUID';
+```
+
+为实际的 formUuid：
+
+```javascript
+const formUuid = 'FORM_ABC123';
+```
+
+### 3. 创建自定义页面
+
+```bash
+cd ../yida-create-page/scripts
+node create-page.js "APP_ID" "联系我们"
+```
+
+记下输出的页面 formUuid
+
+### 4. 发布页面
+
+```bash
+cd ../yida-publish-page/scripts
+node publish.js "APP_ID" "PAGE_FORM_UUID" ../../examples/contact-form/contact-page.js
+```
+
+## 核心代码说明
+
+### 表单数据存储
+
+```javascript
+self.utils.yida.saveFormData({
+  formUuid: 'FORM_XXX',
+  appType: 'APP_XXX',
+  formDataJson: JSON.stringify({
+    textField_name: _customState.name,
+    textField_phone: _customState.phone,
+  })
+}).then(function(res) {
+  self.utils.toast({ title: '提交成功！', type: 'success' });
+});
+```
+
+关键点：
+- `formUuid`: 表单 ID
+- `appType`: 应用 ID  
+- `formDataJson`: JSON 字符串，键为字段 ID（textField_xxx）

--- a/examples/contact-form/contact-page.js
+++ b/examples/contact-form/contact-page.js
@@ -1,0 +1,212 @@
+const _customState = {
+  name: '',
+  phone: '',
+  company: '',
+  message: '',
+  submitted: false,
+};
+
+export function getCustomState(key) {
+  if (key) {
+    return _customState[key];
+  }
+  return { ..._customState };
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+export function didMount() {
+}
+
+export function didUnmount() {
+}
+
+export function renderJsx() {
+  const { timestamp } = this.state;
+  const self = this;
+
+  const styles = {
+    wrapper: {
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      padding: '40px',
+      maxWidth: '600px',
+      margin: '0 auto',
+    },
+    title: {
+      fontSize: '24px',
+      fontWeight: '600',
+      marginBottom: '24px',
+      textAlign: 'center',
+    },
+    formGroup: {
+      marginBottom: '16px',
+    },
+    label: {
+      display: 'block',
+      fontSize: '14px',
+      fontWeight: '500',
+      marginBottom: '8px',
+    },
+    input: {
+      width: '100%',
+      padding: '12px',
+      fontSize: '16px',
+      border: '1px solid #ddd',
+      borderRadius: '4px',
+      boxSizing: 'border-box',
+    },
+    textarea: {
+      width: '100%',
+      padding: '12px',
+      fontSize: '16px',
+      border: '1px solid #ddd',
+      borderRadius: '4px',
+      minHeight: '100px',
+      boxSizing: 'border-box',
+      fontFamily: 'inherit',
+    },
+    button: {
+      width: '100%',
+      padding: '14px',
+      fontSize: '16px',
+      fontWeight: '600',
+      color: '#fff',
+      background: '#1890ff',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      marginTop: '16px',
+    },
+    successBox: {
+      textAlign: 'center',
+      padding: '60px 20px',
+    },
+    successIcon: {
+      fontSize: '48px',
+      marginBottom: '16px',
+    },
+    successTitle: {
+      fontSize: '20px',
+      fontWeight: '600',
+      marginBottom: '8px',
+    },
+  };
+
+  const handleSubmit = () => {
+    const name = _customState.name;
+    const phone = _customState.phone;
+
+    if (!name || !phone) {
+      self.utils.toast({ title: '请填写姓名和联系电话', type: 'warn' });
+      return;
+    }
+
+    const formUuid = 'FORM_YOUR_FORM_UUID';
+    const appType = window.pageConfig.appType;
+
+    self.utils.yida.saveFormData({
+      formUuid: formUuid,
+      appType: appType,
+      formDataJson: JSON.stringify({
+        textField_name: _customState.name,
+        textField_phone: _customState.phone,
+        textField_company: _customState.company,
+        textareaField_message: _customState.message,
+      })
+    }).then(function(res) {
+      self.utils.toast({ title: '提交成功！', type: 'success' });
+      self.setCustomState({ submitted: true });
+    }).catch(function(err) {
+      self.utils.toast({ title: '提交失败: ' + err.message, type: 'error' });
+    });
+  };
+
+  if (_customState.submitted) {
+    return (
+      <div style={styles.wrapper}>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.successBox}>
+          <div style={styles.successIcon}>✓</div>
+          <div style={styles.successTitle}>提交成功！</div>
+          <p>感谢您的留言，我们会尽快与您联系。</p>
+          <button 
+            style={{...styles.button, background: '#666'}}
+            onClick={function() {
+              self.setCustomState({ 
+                submitted: false, 
+                name: '', 
+                phone: '', 
+                company: '', 
+                message: '' 
+              });
+            }}
+          >
+            继续留言
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      
+      <h1 style={styles.title}>联系我们</h1>
+      <p style={{textAlign: 'center', color: '#666', marginBottom: '24px'}}>
+        留下您的信息，我们会尽快与您联系
+      </p>
+
+      <div style={styles.formGroup}>
+        <label style={styles.label}>姓名 *</label>
+        <input 
+          style={styles.input}
+          placeholder="请输入姓名"
+          defaultValue=""
+          onChange={function(e) { _customState.name = e.target.value; }}
+        />
+      </div>
+
+      <div style={styles.formGroup}>
+        <label style={styles.label}>联系电话 *</label>
+        <input 
+          style={styles.input}
+          placeholder="请输入联系电话"
+          defaultValue=""
+          onChange={function(e) { _customState.phone = e.target.value; }}
+        />
+      </div>
+
+      <div style={styles.formGroup}>
+        <label style={styles.label}>公司名称</label>
+        <input 
+          style={styles.input}
+          placeholder="请输入公司名称（选填）"
+          defaultValue=""
+          onChange={function(e) { _customState.company = e.target.value; }}
+        />
+      </div>
+
+      <div style={styles.formGroup}>
+        <label style={styles.label}>留言内容</label>
+        <textarea 
+          style={styles.textarea}
+          placeholder="请输入留言内容（选填）"
+          defaultValue=""
+          onChange={function(e) { _customState.message = e.target.value; }}
+        ></textarea>
+      </div>
+
+      <button style={styles.button} onClick={handleSubmit}>提交</button>
+    </div>
+  );
+}

--- a/examples/contact-form/fields.json
+++ b/examples/contact-form/fields.json
@@ -1,0 +1,6 @@
+[
+  { "type": "TextField", "label": "姓名", "required": true },
+  { "type": "TextField", "label": "联系电话", "required": true },
+  { "type": "TextField", "label": "公司名称", "required": false },
+  { "type": "TextareaField", "label": "留言内容", "required": false }
+]


### PR DESCRIPTION
## 修复内容

### Issue #4: 添加完整表单提交示例

添加  目录，包含完整的留资表单示例：

-  - 表单字段定义
-  - 自定义页面源码  
-  - 详细的使用说明

示例展示：
1. 如何创建表单
2. 如何在自定义页面中收集用户输入
3. 如何调用  存储数据到后端表单

## 关联 Issue

fix #4