### PR TITLE
docs: 优化贡献者模块样式 (OpenClaw 风格)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,24 +154,13 @@ node --check skills/*/scripts/*.js
 
 ### 贡献者
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tbody>
-    <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/yize"><img src="https://avatars.githubusercontent.com/u/1578814?v=4?s=100" width="100px;" alt="九神"/><br /><sub><b>九神</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/alexmm"><img src="https://avatars.githubusercontent.com/u/324539017?v=4?s=100" width="100px;" alt="天晟"/><br /><sub><b>天晟</b></sub></a></td>
-    </tr>
-  </tbody>
-</table>
+Thanks to all contributors:
 
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
+<p align="left">
+  <a href="https://github.com/yize"><img src="https://avatars.githubusercontent.com/u/1578814?v=4&s=48" width="48" height="48" alt="九神" title="九神"/></a> <a href="https://github.com/alexmm"><img src="https://avatars.githubusercontent.com/u/324539017?v=4&s=48" width="48" height="48" alt="天晟" title="天晟"/></a>
+</p>
 
-<!-- ALL-CONTRIBUTORS-LIST:END -->
-
-感谢所有贡献者！
+欢迎提交 PR！一起完善宜搭 AI 技能库。
 
 ---
 


### PR DESCRIPTION
## 概述

参考 OpenClaw 的贡献者展示风格，优化 README 中的贡献者模块。

## 改动内容

- 头像大小从 100x100 改为 48x48
- 从 table 布局改为水平排列
- 每个头像添加 GitHub 链接和 title
- 精简代码，移除多余的 table 标签

## 对比

**之前 (table 格式)**:
```html
<table>
  <tr>
    <td><img width="100px"></td>
    <td><img width="100px"></td>
  </tr>
</table>
```

**之后 (水平排列)**:
```html
<p align="left">
  <a href="..."><img width="48" height="48"></a>
  <a href="..."><img width="48" height="48"></a>
</p>
```

## 文件

- `README.md`