### PR TITLE
fix: 修正天晟 GitHub 用户名为 alex-mm

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ node --check skills/*/scripts/*.js
 Thanks to all contributors:
 
 <p align="left">
-  <a href="https://github.com/yize"><img src="https://avatars.githubusercontent.com/u/1578814?v=4&s=48" width="48" height="48" alt="九神" title="九神"/></a> <a href="https://github.com/alexmm"><img src="https://avatars.githubusercontent.com/u/324539017?v=4&s=48" width="48" height="48" alt="天晟" title="天晟"/></a>
+  <a href="https://github.com/yize"><img src="https://avatars.githubusercontent.com/u/1578814?v=4&s=48" width="48" height="48" alt="九神" title="九神"/></a> <a href="https://github.com/alex-mm"><img src="https://avatars.githubusercontent.com/u/3302053?v=4&s=48" width="48" height="48" alt="天晟" title="天晟"/></a>
 </p>
 
 欢迎提交 PR！一起完善宜搭 AI 技能库。
@@ -184,7 +184,7 @@ Thanks to all contributors:
 
 ## License
 
-[MIT](./LICENSE) © 2026 [天晟](https://github.com/alexmm)
+[MIT](./LICENSE) © 2026 [天晟](https://github.com/alex-mm)
 
 ---
 


### PR DESCRIPTION
## 概述

修正 README 中天晟的 GitHub 用户名和头像。

## 修正内容

| 项目 | 之前 | 之后 |
|------|------|------|
| GitHub 用户名 | alexmm | alex-mm |
| 头像 ID | 324539017 | 3302053 |