### PR TITLE
fix: 修正 SKILL.md 及脚本中的错误路径引用

### DIFF
--- a/skills/yida-custom-page/SKILL.md
+++ b/skills/yida-custom-page/SKILL.md
@@ -87,7 +87,7 @@ node scripts/babel-transform/transform.js <源文件路径>
 ### 部署到宜搭
 
 ```bash
-cd .claude/skills/yida-publish/scripts
+cd .claude/skills/yida-publish-page/scripts
 npm install  # 首次需要安装依赖
 node publish.js <appType> <formUuid> <源文件路径>
 ```

--- a/skills/yida-get-schema/SKILL.md
+++ b/skills/yida-get-schema/SKILL.md
@@ -43,7 +43,7 @@ node .claude/skills/yida-get-schema/scripts/get-schema.js APP_XXX FORM-XXX
 ## 使用方式
 
 ```bash
-node .claude/skills/get-schema/scripts/get-schema.js <appType> <formUuid>
+node .claude/skills/yida-get-schema/scripts/get-schema.js <appType> <formUuid>
 ```
 
 **参数说明**：

--- a/skills/yida-get-schema/scripts/get-schema.js
+++ b/skills/yida-get-schema/scripts/get-schema.js
@@ -14,7 +14,7 @@
  *   若接口返回 302（登录失效），脚本会自动调用 login.py 重新登录后重试。
  *
  * 示例：
- *   node .claude/skills/get-schema/scripts/get-schema.js "APP_XXX" "FORM-XXX"
+ *   node .claude/skills/yida-get-schema/scripts/get-schema.js "APP_XXX" "FORM-XXX"
  *
  * 输出：
  *   - 日志输出到 stderr
@@ -68,7 +68,7 @@ function parseArgs() {
   const args = process.argv.slice(2);
   if (args.length < 2) {
     console.error("用法: node get-schema.js <appType> <formUuid>");
-    console.error('示例：node .claude/skills/get-schema/scripts/get-schema.js "APP_XXX" "FORM-XXX"');
+    console.error('示例：node .claude/skills/yida-get-schema/scripts/get-schema.js "APP_XXX" "FORM-XXX"');
     process.exit(1);
   }
   return {

--- a/skills/yida-publish-page/SKILL.md
+++ b/skills/yida-publish-page/SKILL.md
@@ -86,7 +86,7 @@ node publish.js APP_XXX FORM-XXXXXX pages/src/xxx.js
 - playwright（Python 版，yida-login 依赖）
 
 ```bash
-cd .claude/skills/yida-publish/scripts && npm install
+cd .claude/skills/yida-publish-page/scripts && npm install
 ```
 
 ## 文件结构


### PR DESCRIPTION
## 问题

多处 SKILL.md 和脚本注释中存在错误的路径引用，导致 AI 按文档执行命令时直接报错失败。

## 修改内容

| 文件 | 错误路径 | 正确路径 |
|------|---------|---------|
| `skills/yida-custom-page/SKILL.md` | `yida-publish/scripts`（2处） | `yida-publish-page/scripts` |
| `skills/yida-publish-page/SKILL.md` | `yida-publish/scripts`（2处） | `yida-publish-page/scripts` |
| `skills/yida-get-schema/SKILL.md` | `get-schema/scripts`（2处） | `yida-get-schema/scripts` |
| `skills/yida-get-schema/scripts/get-schema.js` | `get-schema/scripts`（2处） | `yida-get-schema/scripts` |

共修复 **8 处**错误路径引用。

## 关联 Issue

closes #23