### PR TITLE
fix: 修正 yida-app SKILL.md 步骤编号跳跃问题

### DIFF
--- a/skills/yida-app/SKILL.md
+++ b/skills/yida-app/SKILL.md
@@ -312,7 +312,7 @@ node publish.js APP_XXX FORM-XXXXXX pages/src/xxx.js
 
 ---
 
-### Step 8：输出访问链接并直接使用系统浏览器打开
+### Step 7：输出访问链接并直接使用系统浏览器打开
 * 访问地址参考「宜搭应用 url 规则说明」
 
 ## 快速参考


### PR DESCRIPTION
## 问题

`skills/yida-app/SKILL.md` 中的完整开发流程步骤编号存在跳跃，从 Step 3 直接跳到 Step 5，缺少 Step 4，导致 AI 执行时流程理解混乱。

## 修改内容

将 Step 5~8 重新连续编号为 Step 4~7：

| 原编号 | 新编号 | 步骤内容 |
|--------|--------|---------|
| Step 5 | Step 4 | 创建表单（按需） |
| Step 6 | Step 5 | 编写页面代码 |
| Step 7 | Step 6 | 发布代码 |
| Step 8 | Step 7 | 输出访问链接 |

## 关联 Issue

closes #24