### PR TITLE
refactor: 收敛各 SKILL.md 中重复的错误处理逻辑到 yida-login

### DIFF
--- a/skills/yida-create-app/SKILL.md
+++ b/skills/yida-create-app/SKILL.md
@@ -88,9 +88,7 @@ node .claude/skills/yida-create-app/scripts/create-app.js "考勤管理" "员工
 
 1. 读取项目根目录的 `.cache/cookies.json` 获取登录态；若不存在则自动调用 `login.py` 触发扫码登录
 2. 构建 `registerApp` 请求参数
-3. 发送 POST 请求到 `/query/app/registerApp.json`；根据响应体 `errorCode` 自动处理异常：
-   - `errorCode: "TIANSHU_000030"`（csrf 校验失败）→ 自动刷新 csrf_token 后重试
-   - `errorCode: "307"`（登录过期）→ 自动重新登录后重试
+3. 发送 POST 请求到 `/query/app/registerApp.json`；根据响应体 `errorCode` 自动处理异常（详见 `yida-login` 技能文档「错误处理机制」章节）
 4. 从返回值中获取应用 ID（appType）
 5. 将 `appType` 记录到 `prd/<项目名>.md` 备用
 

--- a/skills/yida-create-form-page/SKILL.md
+++ b/skills/yida-create-form-page/SKILL.md
@@ -397,12 +397,10 @@ format 格式：
 
 1. 准备字段定义 JSON 文件
 2. 读取项目根目录的 `.cache/cookies.json` 获取登录态（包含 corpId）；若不存在则自动调用 `login.py` 触发扫码登录
-3. 调用 `saveFormSchemaInfo` 接口创建空白表单，获取 formUuid；根据响应体 `errorCode` 自动处理异常：
-   - `errorCode: "TIANSHU_000030"`（csrf 校验失败）→ 自动刷新 csrf_token 后重试
-   - `errorCode: "307"`（登录过期）→ 自动重新登录后重试
+3. 调用 `saveFormSchemaInfo` 接口创建空白表单，获取 formUuid；根据响应体 `errorCode` 自动处理异常（详见 `yida-login` 技能文档「错误处理机制」章节）
 4. 根据字段定义生成表单 Schema JSON（SerialNumberField 的 formula 会自动使用 corpId、appType、formUuid 和 fieldId 构建）
-5. 调用 `saveFormSchema` 接口保存 Schema；同样根据响应体 `errorCode` 自动处理异常（同上）
-6. 调用 `updateFormConfig` 接口更新表单配置（MINI_RESOURCE = 0）；同样根据响应体 `errorCode` 自动处理异常（同上）
+5. 调用 `saveFormSchema` 接口保存 Schema；同样根据响应体 `errorCode` 自动处理异常
+6. 调用 `updateFormConfig` 接口更新表单配置（MINI_RESOURCE = 0）；同样根据响应体 `errorCode` 自动处理异常
 
 ### update 模式
 

--- a/skills/yida-create-page/SKILL.md
+++ b/skills/yida-create-page/SKILL.md
@@ -74,9 +74,7 @@ node .claude/skills/yida-create-page/scripts/create-page.js "APP_xxx" "游戏主
 ## 调用流程
 
 1. 读取项目根目录的 `.cache/cookies.json` 获取登录态；若不存在则自动调用 `login.py` 触发扫码登录
-2. 调用 `saveFormSchemaInfo` 接口创建 display 类型页面；根据响应体 `errorCode` 自动处理异常：
-   - `errorCode: "TIANSHU_000030"`（csrf 校验失败）→ 自动刷新 csrf_token 后重试
-   - `errorCode: "307"`（登录过期）→ 自动重新登录后重试
+2. 调用 `saveFormSchemaInfo` 接口创建 display 类型页面；根据响应体 `errorCode` 自动处理异常（详见 `yida-login` 技能文档「错误处理机制」章节）
 3. 从返回值中获取页面 ID（formUuid）
 4. **将 `pageId`（formUuid）记录到 `prd/<项目名>.md` 的应用配置章节**
 

--- a/skills/yida-get-schema/SKILL.md
+++ b/skills/yida-get-schema/SKILL.md
@@ -69,9 +69,7 @@ node .claude/skills/get-schema/scripts/get-schema.js "APP_XXX" "FORM-XXX"
 ## 调用流程
 
 1. 读取项目根目录的 `.cache/cookies.json` 获取登录态；若不存在则自动调用 `login.py` 触发扫码登录
-2. 调用 `getFormSchema` 接口获取表单 Schema；根据响应体 `errorCode` 自动处理异常：
-   - `errorCode: "TIANSHU_000030"`（csrf 校验失败）→ 自动刷新 csrf_token 后重试
-   - `errorCode: "307"`（登录过期）→ 自动重新登录后重试
+2. 调用 `getFormSchema` 接口获取表单 Schema；根据响应体 `errorCode` 自动处理异常（详见 `yida-login` 技能文档「错误处理机制」章节）
 3. 将 Schema 输出到 stdout
 
 ## 文件结构

--- a/skills/yida-publish-page/SKILL.md
+++ b/skills/yida-publish-page/SKILL.md
@@ -71,10 +71,8 @@ node publish.js APP_XXX FORM-XXXXXX pages/src/xxx.js
 1. **编译源码**：通过 `@ali/vu-babel-transform` 将 JSX 转换为 ES5，再通过 UglifyJS 压缩
 2. **构建 Schema**：通过代码动态构建完整的 Schema JSON，将编译后的 `source` 和 `compiled` 填入 `actions.module`
 3. **读取登录态**：读取项目根目录的 `.cache/cookies.json`；若不存在则自动调用 `login.py` 触发扫码登录
-4. **发布 Schema**：通过 HTTP POST 调用 `saveFormSchema` 接口保存 Schema；根据响应体 `errorCode` 自动处理异常：
-   - `errorCode: "TIANSHU_000030"`（csrf 校验失败）→ 自动刷新 csrf_token 后重试
-   - `errorCode: "307"`（登录过期）→ 自动重新登录后重试
-5. **更新表单配置**：调用 `updateFormConfig` 接口，设置 `MINI_RESOURCE` 配置为 `8`；同样根据响应体 `errorCode` 自动处理异常（同上）
+4. **发布 Schema**：通过 HTTP POST 调用 `saveFormSchema` 接口保存 Schema；根据响应体 `errorCode` 自动处理异常（详见 `yida-login` 技能文档「错误处理机制」章节）
+5. **更新表单配置**：调用 `updateFormConfig` 接口，设置 `MINI_RESOURCE` 配置为 `8`；同样根据响应体 `errorCode` 自动处理异常
 
 > **注意**：发布目标地址由 `.cache/cookies.json` 中保存的 `base_url` 决定（即登录后浏览器实际跳转到的域名），而非 `config.json` 中的 `loginUrl`。详见 `yida-login` 技能文档。
 > **注意**：当发布页面碰到组织 corpId 不匹配 或  "您当前未在「xxx」组织内" 时，可以询问是否创建新的应用发布。


### PR DESCRIPTION
## 问题

5 个技能文档中各自重复维护了完全相同的 errorCode 错误处理说明，修改时需要同步更新 5 处，维护成本高。

## 修改内容

将以下 5 个文件中重复的两行 errorCode 说明统一改为引用 `yida-login` 技能文档的「错误处理机制」章节：

- `skills/yida-create-app/SKILL.md`
- `skills/yida-create-page/SKILL.md`
- `skills/yida-create-form-page/SKILL.md`（2处）
- `skills/yida-publish-page/SKILL.md`
- `skills/yida-get-schema/SKILL.md`

**修改前**（每处）：
```
根据响应体 errorCode 自动处理异常：
  - errorCode: "TIANSHU_000030"（csrf 校验失败）→ 自动刷新 csrf_token 后重试
  - errorCode: "307"（登录过期）→ 自动重新登录后重试
```

**修改后**（每处）：
```
根据响应体 errorCode 自动处理异常（详见 yida-login 技能文档「错误处理机制」章节）
```

权威的错误处理说明已在 `yida-login/SKILL.md` 的「错误处理机制」章节中完整定义，无需在各技能中重复。

## 关联 Issue

closes #25