### PR TITLE
fix: 补充示例代码中 this 上下文说明，消除歧义

### DIFF
--- a/examples/contact-form/contact-page.js
+++ b/examples/contact-form/contact-page.js
@@ -13,21 +13,28 @@ export function getCustomState(key) {
   return { ..._customState };
 }
 
+// 注意：所有 export function 中的 this 均由宜搭平台绑定为页面 React 类实例，
+// 通过 self.setCustomState() / self.forceUpdate() 等方式调用时 this 指向正确。
+
 export function setCustomState(newState) {
   Object.keys(newState).forEach(function(key) {
     _customState[key] = newState[key];
   });
+  // this 由宜搭平台绑定，调用导出的 forceUpdate 函数触发重新渲染
   this.forceUpdate();
 }
 
 export function forceUpdate() {
+  // 通过更新 timestamp 触发 React 重渲染
   this.setState({ timestamp: new Date().getTime() });
 }
 
 export function didMount() {
+  // 页面加载完成后的初始化逻辑（如有需要可在此处加载数据）
 }
 
 export function didUnmount() {
+  // 页面卸载时的清理逻辑（如有定时器需在此处清除）
 }
 
 export function renderJsx() {


### PR DESCRIPTION
## 问题

`examples/contact-form/contact-page.js` 中 `setCustomState` 调用 `this.forceUpdate()`，但代码中没有任何注释说明 `this` 的来源，容易让参考者误以为这里的 `this` 是 `undefined` 而产生困惑。

## 修改内容

在 `examples/contact-form/contact-page.js` 中补充注释：

1. **文件顶部**：说明所有 `export function` 中的 `this` 均由宜搭平台绑定为页面 React 类实例
2. **`setCustomState`**：说明 `this.forceUpdate()` 调用的是导出的 `forceUpdate` 函数
3. **`forceUpdate`**：说明通过更新 `timestamp` 触发 React 重渲染的机制
4. **`didMount` / `didUnmount`**：补充典型用途说明

代码逻辑本身无变更，仅补充注释消除歧义。

## 关联 Issue

closes #27