### PR TITLE
docs: 移除 README 目录结构中不存在的文件条目

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ yida-skills/
 │   └── contact-form/
 ├── .github/
 │   └── workflows/                 # CI 配置
-├── install.sh                     # 一键安装脚本
-├── getting-started.md             # 快速上手指南
 ├── README.md
 └── LICENSE
 ```


### PR DESCRIPTION
## 问题

`README.md` 的目录结构中描述了两个实际不存在的文件，会误导贡献者：

| 文件 | 状态 |
|------|------|
| `install.sh` | 不存在 |
| `getting-started.md` | 不存在 |

## 修改内容

从目录结构代码块中删除上述两个不存在的文件条目，使文档与实际项目结构保持一致。

## 关联 Issue

closes #28