### PR TITLE
fix: logout.py 改为写入空字符串，修复退出登录后 JS 脚本仍认为有登录态的问题

### DIFF
--- a/skills/yida-logout/scripts/logout.py
+++ b/skills/yida-logout/scripts/logout.py
@@ -10,7 +10,6 @@ logout.py - 宜搭平台退出登录工具。
   下次调用 yida-login 时将重新触发扫码登录。
 """
 
-import json
 import os
 import sys
 
@@ -43,7 +42,7 @@ def main():
         return
 
     with open(COOKIE_FILE, "w", encoding="utf-8") as file:
-        json.dump([], file)
+        file.write("")
 
     print("\n  ✅ 已清空 Cookie，登录态已失效。")
     print("  下次调用 yida-login 时将重新触发扫码登录。")


### PR DESCRIPTION
## 问题

`logout.py` 清空 Cookie 时写入的是空数组 `[]`：

```python
json.dump([], file)  # 写入 []
```

JS 脚本（`create-app.js` 等）的 `loadCookieData` 会将数组格式识别为「旧版 Cookie 格式」并尝试提取 `csrf_token`，导致退出登录后 JS 脚本仍认为有登录态。

## 修改内容

- 将写入内容从 `json.dump([], file)` 改为 `file.write()`，写入空字符串
- 移除不再使用的 `import json`

## 效果

退出登录后，`login.py` 的 `load_login_cache` 和 JS 脚本的 `loadCookieData` 均会因「内容为空」而返回无效状态，行为完全一致。

## 关联 Issue

closes #36