### PR TITLE
fix: 修复 CI JSON 校验命令中 '{}' 不会被 find 替换的 Bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,7 @@ jobs:
 
     - name: Validate JSON files
       run: |
-        find . -name "*.json" -path "./skills/*" -exec node -e "JSON.parse(require('fs').readFileSync('{}'))" \; -print
+        find . -name "*.json" -path "./skills/*" | while read -r file; do
+          node -e "JSON.parse(require('fs').readFileSync(process.argv[1]))" -- "$file" || exit 1
+          echo "  ✅ $file"
+        done


### PR DESCRIPTION
## 问题

`.github/workflows/ci.yml` 中的 JSON 校验命令：

```yaml
find . -name "*.json" -path "./skills/*" -exec node -e "JSON.parse(require('fs').readFileSync('{}'))" \; -print
```

单引号包裹的 `'{}'` **不会被 `find` 替换为实际文件路径**，`node` 实际执行的是 `readFileSync('{}')`，尝试读取名为 `{}` 的文件，导致 JSON 校验从未真正生效。

## 修改内容

改为 `while read -r file` 循环方式，通过 `process.argv[1]` 将文件路径传递给 `node`：

```yaml
find . -name "*.json" -path "./skills/*" | while read -r file; do
  node -e "JSON.parse(require('fs').readFileSync(process.argv[1]))" -- "$file" || exit 1
  echo "  ✅ $file"
done
```

## 关联 Issue

closes #38