### PR TITLE
refactor: create-form-page.js 引入 shared 工具函数，删除重复代码

### DIFF
--- a/skills/yida-create-form-page/scripts/create-form-page.js
+++ b/skills/yida-create-form-page/scripts/create-form-page.js
@@ -61,30 +61,20 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 const querystring = require("querystring");
-const { execSync } = require("child_process");
 
-// ── 配置读取 ──────────────────────────────────────────
-const CONFIG_PATH = path.resolve(findProjectRoot(), "config.json");
-
-function findProjectRoot() {
-  // 优先从调用者工作目录向上找，确保在其他项目中调用时能正确定位
-  for (const startDir of [process.cwd(), __dirname]) {
-    let currentDir = startDir;
-    while (currentDir !== path.dirname(currentDir)) {
-      if (fs.existsSync(path.join(currentDir, "README.md")) ||
-          fs.existsSync(path.join(currentDir, ".git"))) {
-        return currentDir;
-      }
-      currentDir = path.dirname(currentDir);
-    }
-  }
-  return process.cwd();
-}
-const CONFIG = fs.existsSync(CONFIG_PATH) ? JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")) : {};
-const DEFAULT_BASE_URL = CONFIG.defaultBaseUrl || "https://www.aliwork.com";
-const PROJECT_ROOT = findProjectRoot();
-const COOKIE_FILE = path.join(PROJECT_ROOT, ".cache", "cookies.json");
-const LOGIN_SCRIPT = path.join(PROJECT_ROOT, ".claude", "skills", "yida-login", "scripts", "login.py");
+const {
+  findProjectRoot,
+  PROJECT_ROOT,
+  DEFAULT_BASE_URL,
+  COOKIE_FILE,
+  extractInfoFromCookies,
+  loadCookieData,
+  resolveBaseUrl,
+  isLoginExpired,
+  isCsrfTokenExpired,
+  triggerLogin,
+  refreshCsrfToken,
+} = require("../../shared/scripts/yida-utils");
 
 // ── 选项类字段类型 ───────────────────────────────────
 const OPTION_FIELD_TYPES = ["RadioField", "SelectField", "CheckboxField", "MultiSelectField"];
@@ -144,119 +134,6 @@ function parseArgs() {
   console.error('  node .claude/skills/yida-create-form-page/scripts/create-form-page.js create "APP_XXX" "员工信息登记" fields.json');
   console.error('  node .claude/skills/yida-create-form-page/scripts/create-form-page.js update "APP_XXX" "FORM-YYY" \'[{"action":"add","field":{"type":"TextField","label":"备注"}}]\'');
   process.exit(1);
-}
-
-// ── 登录态管理 ───────────────────────────────────────
-
-/**
- * 从 Cookie 列表中提取 csrf_token 和 corp_id
- * - csrf_token：name="tianshu_csrf_token" 的 cookie value
- * - corp_id：name="tianshu_corp_user" 的 cookie value，格式 "{corpId}_{userId}"，按最后一个 "_" 分隔
- */
-function extractInfoFromCookies(cookies) {
-  let csrfToken = null;
-  let corpId = null;
-  for (const cookie of cookies) {
-    if (cookie.name === "tianshu_csrf_token") {
-      csrfToken = cookie.value;
-    } else if (cookie.name === "tianshu_corp_user") {
-      const lastUnderscore = cookie.value.lastIndexOf("_");
-      if (lastUnderscore > 0) {
-        corpId = cookie.value.slice(0, lastUnderscore);
-      }
-    }
-  }
-  return { csrfToken, corpId };
-}
-
-function loadCookieData() {
-  if (!fs.existsSync(COOKIE_FILE)) return null;
-  try {
-    const raw = fs.readFileSync(COOKIE_FILE, "utf-8").trim();
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    let cookieData;
-    if (Array.isArray(parsed)) {
-      cookieData = { cookies: parsed, base_url: DEFAULT_BASE_URL };
-    } else {
-      cookieData = parsed;
-    }
-    // 从 Cookie 中提取 csrf_token 和 corp_id（优先使用 Cookie 中的值）
-    if (cookieData.cookies && cookieData.cookies.length > 0) {
-      const { csrfToken, corpId } = extractInfoFromCookies(cookieData.cookies);
-      if (csrfToken) cookieData.csrf_token = csrfToken;
-      if (corpId) cookieData.corp_id = corpId;
-    }
-    return cookieData;
-  } catch {
-    return null;
-  }
-}
-
-function triggerLogin() {
-  console.error("\n🔐 登录态失效，正在调用 login.py 重新登录...\n");
-  if (!fs.existsSync(LOGIN_SCRIPT)) {
-    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
-    process.exit(1);
-  }
-  const stdout = execSync(`python3 "${LOGIN_SCRIPT}"`, {
-    encoding: "utf-8",
-    stdio: ["inherit", "pipe", "inherit"],
-    timeout: 180_000,
-  });
-  const lines = stdout.trim().split("\n");
-  const jsonLine = lines[lines.length - 1];
-  try {
-    const loginResult = JSON.parse(jsonLine);
-    if (!loginResult.cookies) throw new Error("登录结果缺少 cookies");
-    return loginResult;
-  } catch (err) {
-    console.error(`  ❌ 解析登录结果失败: ${err.message}`);
-    process.exit(1);
-  }
-}
-
-function resolveBaseUrl(cookieData) {
-  return ((cookieData && cookieData.base_url) || DEFAULT_BASE_URL).replace(/\/+$/, "");
-}
-
-/**
- * 检测响应体是否表示登录过期
- * 登录过期响应：{"success":false,"errorCode":"307","errorMsg":"登录状态已过期，请刷新页面后重新访问"}
- */
-function isLoginExpired(responseJson) {
-  return responseJson && responseJson.success === false && responseJson.errorCode === "307";
-}
-
-/**
- * 检测响应体是否表示 csrf_token 过期
- * csrf 过期响应：{"success":false,"errorCode":"TIANSHU_000030","errorMsg":"csrf校验失败"}
- */
-function isCsrfTokenExpired(responseJson) {
-  return responseJson && responseJson.success === false && responseJson.errorCode === "TIANSHU_000030";
-}
-
-function refreshCsrfToken() {
-  console.error("\n🔄 csrf_token 已过期，正在刷新...\n");
-  if (!fs.existsSync(LOGIN_SCRIPT)) {
-    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
-    process.exit(1);
-  }
-  const stdout = execSync(`python3 "${LOGIN_SCRIPT}" --refresh-csrf`, {
-    encoding: "utf-8",
-    stdio: ["inherit", "pipe", "inherit"],
-    timeout: 60_000,
-  });
-  const lines = stdout.trim().split("\n");
-  const jsonLine = lines[lines.length - 1];
-  try {
-    const result = JSON.parse(jsonLine);
-    if (!result.csrf_token || !result.cookies) throw new Error("刷新结果缺少 csrf_token 或 cookies");
-    return result;
-  } catch (err) {
-    console.error(`  ❌ 解析刷新结果失败: ${err.message}`);
-    process.exit(1);
-  }
 }
 
 // ── 读取字段定义 ─────────────────────────────────────


### PR DESCRIPTION
## 关联 Issue

关闭 #43，关闭 #44

## 变更内容

`create-form-page.js` 是 PR #42 合并时遗漏的脚本，本 PR 补齐：

### 引入 shared 工具函数（关闭 #43）

- 删除本地重复的 8 个公共函数：`findProjectRoot`、`extractInfoFromCookies`、`loadCookieData`、`triggerLogin`、`resolveBaseUrl`、`isLoginExpired`、`isCsrfTokenExpired`、`refreshCsrfToken`
- 改为 `require('../../shared/scripts/yida-utils')` 统一引入
- 净减少 **137 行**重复代码

### console.log/error 排查（关闭 #44）

经逐行排查，文件中所有 `console.log` 均为最终 JSON 结果输出（`console.log(JSON.stringify(...))`），日志类输出本已全部使用 `console.error`，无需修改，Issue #44 描述的问题在此文件中不存在。

## 测试

- [x] `node --check` 语法验证通过