### PR TITLE
fix: CI JS 语法校验 glob 补充覆盖 shared 目录

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Validate JavaScript syntax
       run: |
-        for file in skills/*/scripts/*.js; do
+        for file in skills/*/scripts/*.js skills/shared/scripts/*.js; do
           node --check "$file" || exit 1
         done
 


### PR DESCRIPTION
## 关联 Issue

关闭 #45

## 问题

`.github/workflows/ci.yml` 中 JS 语法校验使用的 glob 为 `skills/*/scripts/*.js`，该单层通配符不匹配 `skills/shared/scripts/yida-utils.js`，导致共享工具模块的语法错误无法被 CI 检测到。

## 修复

在 for 循环中追加 `skills/shared/scripts/*.js`，确保 shared 目录下的所有 JS 文件也被语法校验覆盖：

```yaml
for file in skills/*/scripts/*.js skills/shared/scripts/*.js; do
```

## 影响

- 覆盖范围从原来的各 skill 脚本扩展到包含 `skills/shared/scripts/` 下所有 JS 文件
- 不影响现有校验逻辑，仅增加校验范围