### PR TITLE
fix: publish.js 补充 timeout 配置，logout.py 日志改走 stderr

### DIFF
--- a/skills/yida-logout/scripts/logout.py
+++ b/skills/yida-logout/scripts/logout.py
@@ -31,22 +31,22 @@ COOKIE_FILE = os.path.join(find_project_root(SCRIPT_DIR), ".cache", "cookies.jso
 
 
 def main():
-    print("=" * 50)
-    print("  yida-logout - 宜搭退出登录工具")
-    print("=" * 50)
-    print(f"\n  Cookie 文件: {COOKIE_FILE}")
+    print("=" * 50, file=sys.stderr)
+    print("  yida-logout - 宜搭退出登录工具", file=sys.stderr)
+    print("=" * 50, file=sys.stderr)
+    print(f"\n  Cookie 文件: {COOKIE_FILE}", file=sys.stderr)
 
     if not os.path.exists(COOKIE_FILE):
-        print("\n  ℹ️  Cookie 文件不存在，无需清除。")
-        print("=" * 50)
+        print("\n  ℹ️  Cookie 文件不存在，无需清除。", file=sys.stderr)
+        print("=" * 50, file=sys.stderr)
         return
 
     with open(COOKIE_FILE, "w", encoding="utf-8") as file:
         file.write("")
 
-    print("\n  ✅ 已清空 Cookie，登录态已失效。")
-    print("  下次调用 yida-login 时将重新触发扫码登录。")
-    print("=" * 50)
+    print("\n  ✅ 已清空 Cookie，登录态已失效。", file=sys.stderr)
+    print("  下次调用 yida-login 时将重新触发扫码登录。", file=sys.stderr)
+    print("=" * 50, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/skills/yida-publish-page/scripts/publish.js
+++ b/skills/yida-publish-page/scripts/publish.js
@@ -375,6 +375,7 @@ function sendSaveRequest(csrfToken, cookies, schemaContent, baseUrl, appType, fo
         Referer: `${baseUrl}/`,
         Cookie: cookieHeader,
       },
+      timeout: 30000,
     };
 
     const request = requestModule.request(requestOptions, (response) => {
@@ -404,6 +405,12 @@ function sendSaveRequest(csrfToken, cookies, schemaContent, baseUrl, appType, fo
         }
         resolve(parsed);
       });
+    });
+
+    request.on("timeout", () => {
+      console.error("  ❌ 请求超时");
+      request.destroy();
+      reject(new Error("请求超时"));
     });
 
     request.on("error", (requestError) => { reject(requestError); });
@@ -447,6 +454,7 @@ function sendUpdateConfigRequest(csrfToken, cookies, baseUrl, appType, formUuid,
         Referer: `${baseUrl}/`,
         Cookie: cookieHeader,
       },
+      timeout: 30000,
     };
 
     const request = requestModule.request(requestOptions, (response) => {
@@ -476,6 +484,12 @@ function sendUpdateConfigRequest(csrfToken, cookies, baseUrl, appType, formUuid,
         }
         resolve(parsed);
       });
+    });
+
+    request.on("timeout", () => {
+      console.error("  ❌ 请求超时");
+      request.destroy();
+      reject(new Error("请求超时"));
     });
 
     request.on("error", (requestError) => { reject(requestError); });


### PR DESCRIPTION
## 关联 Issue

关闭 #49，关闭 #50

## 变更内容

### publish.js 补充 timeout（关闭 #49）

`sendSaveRequest` 和 `sendUpdateConfigRequest` 两个函数的 `requestOptions` 中补充了 `timeout: 30000`，并新增 `request.on('timeout')` 超时处理回调，与 `create-app.js`、`create-page.js` 保持一致，避免接口无响应时脚本无限挂起。

### logout.py 日志改走 stderr（关闭 #50）

将 `main()` 中所有日志类 `print` 改为 `print(..., file=sys.stderr)`，遵循项目约定「日志走 stderr，JSON 结果走 stdout」，与 `login.py` 保持一致。

## 测试

- [x] `node --check` 语法验证通过（publish.js）
- [x] `python3 -c "import ast; ast.parse(...)"` 语法验证通过（logout.py）