### PR TITLE
refactor: 清理各 JS 脚本中未使用的 shared 模块导入

### DIFF
--- a/skills/yida-create-app/scripts/create-app.js
+++ b/skills/yida-create-app/scripts/create-app.js
@@ -35,10 +35,6 @@ const querystring = require("querystring");
 
 const {
   findProjectRoot,
-  PROJECT_ROOT,
-  DEFAULT_BASE_URL,
-  COOKIE_FILE,
-  extractInfoFromCookies,
   loadCookieData,
   resolveBaseUrl,
   isLoginExpired,

--- a/skills/yida-create-page/scripts/create-page.js
+++ b/skills/yida-create-page/scripts/create-page.js
@@ -30,11 +30,6 @@ const path = require("path");
 const querystring = require("querystring");
 
 const {
-  findProjectRoot,
-  PROJECT_ROOT,
-  DEFAULT_BASE_URL,
-  COOKIE_FILE,
-  extractInfoFromCookies,
   loadCookieData,
   resolveBaseUrl,
   isLoginExpired,

--- a/skills/yida-get-schema/scripts/get-schema.js
+++ b/skills/yida-get-schema/scripts/get-schema.js
@@ -34,11 +34,6 @@ const path = require("path");
 const querystring = require("querystring");
 
 const {
-  findProjectRoot,
-  PROJECT_ROOT,
-  DEFAULT_BASE_URL,
-  COOKIE_FILE,
-  extractInfoFromCookies,
   loadCookieData,
   resolveBaseUrl,
   isLoginExpired,


### PR DESCRIPTION
## 关联 Issue

关闭 #48

## 变更内容

从 `create-app.js`、`create-page.js`、`get-schema.js` 的 `require` 解构中移除未使用的符号：

| 文件 | 移除的导入 |
| --- | --- |
| `create-app.js` | `PROJECT_ROOT`、`DEFAULT_BASE_URL`、`COOKIE_FILE`、`extractInfoFromCookies` |
| `create-page.js` | `findProjectRoot`、`PROJECT_ROOT`、`DEFAULT_BASE_URL`、`COOKIE_FILE`、`extractInfoFromCookies` |
| `get-schema.js` | `findProjectRoot`、`PROJECT_ROOT`、`DEFAULT_BASE_URL`、`COOKIE_FILE`、`extractInfoFromCookies` |

> **注意**：`create-app.js` 保留了 `findProjectRoot`，因为 `compiledPath` 计算中有直接调用。

## 测试

- [x] 三个文件 `node --check` 语法验证通过