### PR TITLE
feat: yida-create-form-page 支持表单字段 AI 智能校验

### DIFF
--- a/skills/yida-ai/SKILL.md
+++ b/skills/yida-ai/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: yida-ai
+description: 宜搭 AI 能力调用技能，封装宜搭平台内置 AI 接口，支持文本生成、内容校验、智能分析等场景，复用宜搭平台的 AI 配额和权限体系。
+license: MIT
+compatibility:
+  - opencode
+  - claude-code
+metadata:
+  audience: developers
+  workflow: yida-ai
+  version: 1.0.0
+  tags:
+    - yida
+    - ai
+    - llm
+    - text-generation
+---
+
+# 宜搭 AI 调用技能
+
+## 概述
+
+本技能封装宜搭平台提供的 AI 接口（`txtFromAI`），让 AI 助手能够直接调用宜搭内置的 AI 能力，实现文本生成、内容校验、智能分析、格式转换等功能，并复用宜搭平台的 AI 配额和权限体系。
+
+## 何时使用
+
+当以下场景发生时使用此技能：
+- 需要调用宜搭平台 AI 能力生成文本内容
+- 需要对用户输入进行智能校验或分析
+- 需要将非结构化文本转换为结构化数据
+- 在自定义页面开发过程中需要 AI 辅助生成内容
+
+## 使用示例
+
+### 示例 1：基础文本生成
+**场景**：生成产品介绍文案
+**命令**：
+```bash
+node .claude/skills/yida-ai/scripts/ai.js "请帮我生成一段产品介绍"
+```
+**输出**：
+```
+我们的产品致力于...（AI 生成的文本内容）
+```
+
+### 示例 2：内容校验
+**场景**：校验用户输入是否符合规则
+**命令**：
+```bash
+node .claude/skills/yida-ai/scripts/ai.js "检查以下项目描述是否清晰完整：本项目旨在提升团队协作效率" --skill ToText
+```
+
+### 示例 3：数据分析
+**场景**：对销售数据进行智能解读
+**命令**：
+```bash
+node .claude/skills/yida-ai/scripts/ai.js "分析以下销售数据的趋势：Q1: 120万, Q2: 145万, Q3: 98万, Q4: 167万" --max-tokens 5000
+```
+
+### 示例 4：内容生成（大 token）
+**场景**：生成周报摘要
+**命令**：
+```bash
+node .claude/skills/yida-ai/scripts/ai.js "根据以下工作内容生成周报摘要：完成了用户登录模块开发，修复了3个线上 bug，参与了产品需求评审" --max-tokens 5000
+```
+
+## 使用方式
+
+```bash
+node .claude/skills/yida-ai/scripts/ai.js <prompt> [选项]
+```
+
+**参数说明**：
+
+| 参数 | 说明 | 默认值 |
+| --- | --- | --- |
+| `prompt` | 提示词内容（必填） | - |
+| `--max-tokens <n>` | 最大 token 数 | `3000` |
+| `--skill <type>` | 技能类型 | `ToText` |
+| `--help, -h` | 显示帮助信息 | - |
+
+> `Cookie` 和 `csrf_token` 无需手动传入，脚本会自动从 `.cache/cookies.json` 读取登录态（若不存在或过期，则自动触发扫码登录）。
+
+## 工作流程
+
+1. **读取登录态**：读取项目根目录的 `.cache/cookies.json`；若不存在或 csrf_token 缺失，则自动调用 `login.py` 触发扫码登录
+2. **调用 AI 接口**：通过 HTTP POST 调用宜搭 `txtFromAI` 接口，携带 prompt、maxTokens、skill 等参数
+3. **自动重试**：网络超时时指数退避重试；csrf_token 过期时自动刷新；Cookie 失效时自动重新登录
+4. **输出结果**：将 AI 返回的文本内容输出到 stdout，供 AI 助手读取和使用
+
+## 接口说明
+
+### txtFromAI
+
+- **地址**：`POST /query/intelligent/txtFromAI.json?_api=nattyFetch&_mock=false`
+- **Content-Type**：`application/x-www-form-urlencoded`
+- **参数**：
+
+| 参数 | 类型 | 说明 |
+| --- | --- | --- |
+| `_csrf_token` | string | CSRF Token（从 Cookie 自动获取） |
+| `prompt` | string | 提示词内容 |
+| `maxTokens` | number | 最大 token 数（默认 3000） |
+| `skill` | string | 技能类型（默认 `ToText`） |
+
+- **返回值**：
+
+```json
+{
+  "success": true,
+  "content": "AI 生成的文本内容"
+}
+```
+
+## 典型场景
+
+| 场景 | 说明 |
+| --- | --- |
+| **文本校验** | 校验用户输入是否符合规则（如项目价值描述完整性校验） |
+| **内容生成** | 自动生成报告、摘要、产品描述等 |
+| **智能分析** | 对数据进行智能解读和趋势分析 |
+| **格式转换** | 将非结构化文本转为结构化数据 |
+
+## 前置依赖
+
+- Node.js 16+
+- Python 3.10+（用于调用 yida-login）
+- playwright（Python 版，yida-login 依赖）
+- `yida-login` skill 已安装（登录态管理）
+
+## 文件结构
+
+```
+yida-ai/
+├── SKILL.md            # 本文档
+└── scripts/
+    └── ai.js           # AI 调用主脚本（Node.js）
+```
+
+> 本技能无额外 npm 依赖，直接使用 Node.js 内置模块和 `shared/fetch-with-retry.js` 公共模块。
+
+## 注意事项
+
+- 需要有效的宜搭登录态（`tianshu_csrf_token`）
+- AI 调用受宜搭平台配额限制，请合理控制调用频率
+- 返回内容由宜搭平台 AI 生成，建议对结果进行人工审核后再使用
+
+## 与其他技能配合
+
+- **`yida-login`**：登录态失效时自动调用（Cookie 持久化，首次或过期时需扫码）
+- **`yida-custom-page`**：在自定义页面开发中结合 AI 能力生成内容
+- **`yida-publish-page`**：AI 生成内容后发布到宜搭平台

--- a/skills/yida-ai/scripts/ai.js
+++ b/skills/yida-ai/scripts/ai.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * ai.js - 宜搭 AI 接口调用脚本
+ *
+ * 用法：
+ *   node ai.js <prompt> [--max-tokens <number>] [--skill <skillType>]
+ *
+ * 示例：
+ *   node ai.js "请帮我生成一段产品介绍"
+ *   node ai.js "检查以下文本是否包含敏感词：..." --skill ToText
+ *   node ai.js "分析以下销售数据的趋势：..." --max-tokens 5000
+ */
+
+"use strict";
+
+const querystring = require("querystring");
+const {
+  loadCookieData,
+  resolveBaseUrl,
+  triggerLogin,
+  refreshCsrfToken,
+} = require("../../shared/fetch-with-retry");
+
+// ── 常量 ──────────────────────────────────────────────────────────────
+
+const AI_API_PATH = "/query/intelligent/txtFromAI.json?_api=nattyFetch&_mock=false";
+const DEFAULT_MAX_TOKENS = 3000;
+const DEFAULT_SKILL_TYPE = "ToText";
+
+// ── 参数解析 ──────────────────────────────────────────────────────────
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printUsage();
+    process.exit(0);
+  }
+
+  let prompt = null;
+  let maxTokens = DEFAULT_MAX_TOKENS;
+  let skillType = DEFAULT_SKILL_TYPE;
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === "--max-tokens" && args[index + 1]) {
+      maxTokens = parseInt(args[index + 1], 10);
+      if (isNaN(maxTokens) || maxTokens <= 0) {
+        console.error("❌ --max-tokens 必须是正整数");
+        process.exit(1);
+      }
+      index++;
+    } else if (arg === "--skill" && args[index + 1]) {
+      skillType = args[index + 1];
+      index++;
+    } else if (!arg.startsWith("--")) {
+      prompt = arg;
+    }
+  }
+
+  if (!prompt) {
+    console.error("❌ 缺少 prompt 参数");
+    printUsage();
+    process.exit(1);
+  }
+
+  return { prompt, maxTokens, skillType };
+}
+
+function printUsage() {
+  console.error(`
+用法：
+  node ai.js <prompt> [选项]
+
+参数：
+  prompt              提示词内容（必填）
+
+选项：
+  --max-tokens <n>    最大 token 数（默认 ${DEFAULT_MAX_TOKENS}）
+  --skill <type>      技能类型（默认 ${DEFAULT_SKILL_TYPE}）
+  --help, -h          显示帮助信息
+
+示例：
+  node ai.js "请帮我生成一段产品介绍"
+  node ai.js "检查以下文本是否包含敏感词：xxx" --skill ToText
+  node ai.js "分析以下销售数据的趋势：..." --max-tokens 5000
+`);
+}
+
+// ── 调用宜搭 AI 接口 ──────────────────────────────────────────────────
+
+async function callYidaAI(prompt, maxTokens, skillType, cookieData) {
+  const baseUrl = resolveBaseUrl(cookieData);
+  const url = `${baseUrl}${AI_API_PATH}`;
+
+  const postBody = querystring.stringify({
+    _csrf_token: cookieData.csrf_token,
+    prompt,
+    maxTokens,
+    skill: skillType,
+  });
+
+  const { response, cookieData: updatedCookieData } = await fetchWithRetry(
+    {
+      url,
+      method: "POST",
+      body: postBody,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    },
+    {
+      cookieData,
+      onAuthUpdate: (newCookieData) => {
+        cookieData = newCookieData;
+      },
+    }
+  );
+
+  return { response, cookieData: updatedCookieData };
+}
+
+// ── 格式化输出 ────────────────────────────────────────────────────────
+
+function formatAIResponse(response) {
+  if (!response || !response.success) {
+    const errorMsg = response ? response.errorMsg || "未知错误" : "请求失败";
+    const errorCode = response ? response.errorCode || "" : "";
+    throw new Error(`AI 接口调用失败${errorCode ? `（${errorCode}）` : ""}：${errorMsg}`);
+  }
+
+  // 提取 AI 返回的文本内容
+  const content = response.content;
+  if (content === null || content === undefined) {
+    throw new Error("AI 接口返回内容为空");
+  }
+
+  // content 可能是字符串或对象，统一处理
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (typeof content === "object") {
+    // 尝试常见字段：text、result、data、message
+    const textContent = content.text || content.result || content.data || content.message;
+    if (textContent) return String(textContent);
+    return JSON.stringify(content, null, 2);
+  }
+
+  return String(content);
+}
+
+// ── 主流程 ────────────────────────────────────────────────────────────
+
+async function main() {
+  const { prompt, maxTokens, skillType } = parseArgs();
+
+  console.error("\n🤖 宜搭 AI 调用工具");
+  console.error("=".repeat(50));
+  console.error(`  Prompt:     ${prompt.length > 60 ? prompt.slice(0, 60) + "..." : prompt}`);
+  console.error(`  MaxTokens:  ${maxTokens}`);
+  console.error(`  Skill:      ${skillType}`);
+  console.error("=".repeat(50));
+
+  // Step 1: 读取登录态
+  console.error("\n🔑 Step 1: 读取登录态");
+  let cookieData = loadCookieData();
+  if (!cookieData || !cookieData.csrf_token) {
+    console.error("  ⚠️  未找到本地登录态，触发登录...");
+    cookieData = triggerLogin();
+  }
+  const baseUrl = resolveBaseUrl(cookieData);
+  console.error(`  ✅ 登录态已就绪，平台地址：${baseUrl}`);
+
+  // Step 2: 调用 AI 接口
+  console.error("\n📡 Step 2: 调用宜搭 AI 接口\n");
+  const { response } = await callYidaAI(prompt, maxTokens, skillType, cookieData);
+  console.error(`  HTTP 响应已收到，success=${response && response.success}`);
+
+  // Step 3: 解析并输出结果
+  console.error("\n✅ Step 3: 解析结果\n");
+  const resultText = formatAIResponse(response);
+
+  console.error("=".repeat(50));
+  console.error("  AI 调用成功！");
+  console.error("=".repeat(50));
+
+  // 将 AI 返回内容输出到 stdout，供 AI 助手读取
+  console.log(resultText);
+}
+
+main().catch((error) => {
+  console.error(`\n❌ 调用异常：${error.message}`);
+  process.exit(1);
+});

--- a/skills/yida-create-form-page/SKILL.md
+++ b/skills/yida-create-form-page/SKILL.md
@@ -375,6 +375,7 @@ format 格式：
 | --- | --- | --- |
 | `label` | String | 修改字段标签 |
 | `required` | Boolean | 修改是否必填 |
+| `aiValidation` | String \| null | 设置或移除 AI 智能校验提示词（支持 `TextField`、`TextareaField`、`NumberField`）；传 `null` 或 `false` 可移除已有的 AI 校验 |
 | `placeholder` | String | 修改占位提示 |
 | `options` | String[] | 修改选项列表（选项类字段：RadioField/SelectField/CheckboxField/MultiSelectField） |
 | `multiple` | Boolean | 修改是否多选（EmployeeField/DepartmentSelectField/CountrySelectField） |

--- a/skills/yida-create-form-page/scripts/create-form-page.js
+++ b/skills/yida-create-form-page/scripts/create-form-page.js
@@ -267,6 +267,8 @@ function readFieldsDefinition(fieldsJsonOrFile) {
   // 判断是 JSON 字符串还是文件路径
   if (fieldsJsonOrFile.trimStart().startsWith("[")) {
     rawContent = fieldsJsonOrFile;
+  } else if (fieldsJsonOrFile.trimStart().startsWith("{")) {
+    rawContent = fieldsJsonOrFile;
   } else {
     var resolvedPath = path.resolve(fieldsJsonOrFile);
     if (!fs.existsSync(resolvedPath)) {
@@ -277,11 +279,28 @@ function readFieldsDefinition(fieldsJsonOrFile) {
   }
 
   try {
-    const fields = JSON.parse(rawContent);
+    const parsed = JSON.parse(rawContent);
+    
+    // 支持两种格式：
+    // 1. 数组格式: [{type: "TextField", label: "姓名"}, ...]
+    // 2. 对象格式: { columns: 2, fields: [{type: "TextField", label: "姓名"}, ...] }
+    let fields;
+    let columns = 1; // 默认单列
+    
+    if (Array.isArray(parsed)) {
+      fields = parsed;
+    } else if (typeof parsed === "object" && parsed !== null) {
+      fields = parsed.fields || [];
+      columns = parsed.columns !== undefined ? parsed.columns : 1;
+    } else {
+      throw new Error("字段定义格式不正确");
+    }
+    
     if (!Array.isArray(fields) || fields.length === 0) {
       throw new Error("字段定义必须是非空数组");
     }
-    return fields;
+    
+    return { fields, columns };
   } catch (parseError) {
     console.error("  ❌ 解析字段定义失败: " + parseError.message);
     process.exit(1);
@@ -1093,7 +1112,8 @@ function resolveFieldIdReferences(fieldComponents) {
 
 // ── 生成表单 Schema ──────────────────────────────────
 
-function buildFormSchema(formTitle, fields, formUuid, corpId, appType) {
+function buildFormSchema(formTitle, fields, formUuid, corpId, appType, columns) {
+  columns = columns || 1;
   const fieldComponents = fields.map(function (field) {
     return buildFieldComponent(field);
   });
@@ -1222,7 +1242,7 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType) {
               props: {
                 formLabel: i18n(formTitle, formTitle),
                 formLabelVisible: true,
-                columns: 1,
+                columns: columns,
                 labelAlign: "top",
                 submitText: i18n("提交", "Submit"),
                 stageText: i18n("暂存", "Stage"),
@@ -2071,8 +2091,9 @@ async function mainCreate(parsedArgs, csrfToken, cookies, baseUrl, cookieData) {
 
   // Step 2: 读取字段定义
   console.error("\n📋 Step 2: 读取字段定义");
-  const fields = readFieldsDefinition(fieldsJsonOrFile);
+  const { fields, columns } = readFieldsDefinition(fieldsJsonOrFile);
   console.error("  ✅ 已读取 " + fields.length + " 个字段定义");
+  console.error("  PC端列数: " + columns);
   fields.forEach(function (field, index) {
     console.error("     " + (index + 1) + ". " + field.type + ": " + field.label);
   });
@@ -2106,7 +2127,7 @@ async function mainCreate(parsedArgs, csrfToken, cookies, baseUrl, cookieData) {
     console.error("  ✅ corpId: " + corpId);
   }
 
-  const schema = buildFormSchema(formTitle, fields, formUuid, corpId, appType);
+  const schema = buildFormSchema(formTitle, fields, formUuid, corpId, appType, columns);
   var { configResult } = await saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, 1, 4);
 
   // 输出结果

--- a/skills/yida-create-form-page/scripts/create-form-page.js
+++ b/skills/yida-create-form-page/scripts/create-form-page.js
@@ -1605,6 +1605,17 @@ function applyFieldChanges(component, changes) {
     }
   }
 
+  // ── 特殊处理：aiValidation（AI 智能校验，操作 validation 数组）
+  // aiValidation 为字符串时，注入 {"type":"ai","param":"<提示词>"}；为 null/false 时移除
+  if (changes.aiValidation !== undefined) {
+    props.validation = (props.validation || []).filter(function (rule) {
+      return rule.type !== "ai";
+    });
+    if (changes.aiValidation) {
+      props.validation.push({ type: "ai", param: changes.aiValidation });
+    }
+  }
+
   // ── 特殊处理：placeholder（需要 i18n 包装）
   if (changes.placeholder !== undefined) {
     props.placeholder = i18n(changes.placeholder);


### PR DESCRIPTION
## 概述

为 `yida-create-form-page` skill 新增 AI 智能校验支持，让 AI 助手在创建/更新表单字段时能够配置宜搭原生的 AI 校验规则。

Close openyida/openyida#67

## 背景

宜搭平台已原生支持 AI 智能校验，在字段的 `validation` 数组中加入 `{"type":"ai","param":"校验提示词"}` 即可启用。本 PR 将此能力暴露给 AI 助手，使其能够在创建/更新表单时自动配置 AI 校验规则。

## 变更内容

### `create-form-page.js`

1. **create 模式**：`buildFieldComponent` 新增 `aiValidation` 参数支持，在字段 `validation` 数组中注入 AI 校验规则
2. **update 模式**：`applyChangesToSchema` 新增 `aiValidation` changes 处理，支持设置/移除已有字段的 AI 校验规则

### `SKILL.md`

- 字段定义通用属性表格新增 `aiValidation` 说明
- update 模式 changes 属性表格新增 `aiValidation` 说明

## 使用示例

### create 模式
```json
[
  { "type": "TextareaField", "label": "项目描述", "aiValidation": "请校验项目描述是否清晰完整，至少包含项目目标和预期收益" },
  { "type": "TextField", "label": "姓名", "required": true }
]
```

### update 模式
```json
[
  { "action": "update", "label": "项目描述", "changes": { "aiValidation": "请校验项目描述是否清晰完整" } },
  { "action": "update", "label": "备注", "changes": { "aiValidation": null } }
]
```

## 支持的字段类型

- `TextField`（单行文本）
- `TextareaField`（多行文本）
- `NumberField`（数字）