### PR TITLE
feat: add yida-form-permission skill

### DIFF
--- a/skills/yida-form-permission/SKILL.md
+++ b/skills/yida-form-permission/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: yida-form-permission
+description: 宜搭表单权限配置技能，支持查询和配置表单的字段权限（可见/隐藏/只读/可编辑）、数据权限（全部/本人/本部门/自定义）和操作权限（增删改查导出）。
+license: MIT
+compatibility:
+- opencode
+- claude-code
+metadata:
+  audience: developers
+  workflow: yida-development
+  version: 1.0.0
+  tags:
+  - yida
+  - low-code
+  - permission
+  - form-permission
+---
+
+# 宜搭表单权限配置技能
+
+## 概述
+
+本技能提供宜搭表单的权限配置功能，支持三种维度的权限控制：
+
+| 权限维度 | 说明 |
+|---------|------|
+| **字段权限** | 控制不同角色对表单字段的可见性：可见、隐藏、只读、可编辑、脱敏 |
+| **数据权限** | 控制不同角色可访问的数据范围：全部数据、本人数据、本部门数据、自定义规则 |
+| **操作权限** | 控制不同角色对表单的操作能力：新增、查看、编辑、删除、导出 |
+
+> ⚠️ **当前限制**：
+> - **权限成员**：仅支持「全部人员」（`DEFAULT`）和「管理员」（`MANAGER`）两种类型，暂不支持「权限矩阵」
+> - **数据范围**：暂不支持「自定义部门」（`CUSTOM_DEPARTMENT`）和「自定义过滤条件」（`FORMULA`/`CUSTOM`）
+> - **字段权限**：暂不支持自定义字段权限配置（接口尚未验证），如需配置请通过宜搭管理后台手动操作
+
+## 何时使用
+
+当以下场景发生时使用此技能：
+
+- 用户需要配置表单的字段级权限（如隐藏敏感字段）
+- 用户需要配置数据范围权限（如只能看自己的数据）
+- 用户需要配置操作权限（如禁止删除）
+- 用户需要查看当前表单的权限配置
+
+## 使用示例
+
+### 示例 1：查询表单权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/get-permission.js APP_XXX FORM-XXX
+```
+
+### 示例 2：保存字段权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX '[{"fieldId":"textField_xxx","behavior":"HIDDEN","roles":["member"]},{"fieldId":"numberField_xxx","behavior":"READONLY","roles":["member"]}]'
+```
+
+### 示例 3：保存数据权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX --data-permission '{"role":"member","dataRange":"SELF"}'
+```
+
+### 示例 4：保存操作权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX --action-permission '{"role":"member","actions":{"create":true,"view":true,"edit":false,"delete":false,"export":false}}'
+```
+
+## 工具说明
+
+### 1. get-permission - 获取权限配置
+
+获取表单当前的权限配置信息。
+
+```bash
+node .claude/skills/yida-form-permission/scripts/get-permission.js <appType> <formUuid>
+```
+
+**参数**：
+
+| 参数 | 必填 | 说明 |
+| --- | --- | --- |
+| `appType` | 是 | 应用 ID，如 `APP_XXX` |
+| `formUuid` | 是 | 表单 UUID，如 `FORM-XXX` |
+
+**输出**：
+
+```json
+{
+  "success": true,
+  "permissions": {
+    "fieldPermissions": [
+      {
+        "fieldId": "textField_xxx",
+        "label": "姓名",
+        "behavior": "NORMAL",
+        "roles": ["all"]
+      }
+    ],
+    "dataPermissions": [
+      {
+        "role": "member",
+        "dataRange": "SELF"
+      }
+    ],
+    "actionPermissions": [
+      {
+        "role": "member",
+        "actions": {
+          "create": true,
+          "view": true,
+          "edit": false,
+          "delete": false,
+          "export": false
+        }
+      }
+    ]
+  }
+}
+```
+
+### 2. save-permission - 保存权限配置
+
+保存表单的权限配置。
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js <appType> <formUuid> [fieldPermissionsJson] [--data-permission <json>] [--action-permission <json>]
+```
+
+**参数**：
+
+| 参数 | 必填 | 说明 |
+| --- | --- | --- |
+| `appType` | 是 | 应用 ID |
+| `formUuid` | 是 | 表单 UUID |
+| `fieldPermissionsJson` | 否 | 字段权限 JSON 数组 |
+| `--data-permission` | 否 | 数据权限 JSON |
+| `--action-permission` | 否 | 操作权限 JSON |
+
+#### 字段权限 JSON 格式
+
+```json
+[
+  {
+    "fieldId": "textField_xxx",
+    "behavior": "HIDDEN",
+    "roles": ["member"]
+  },
+  {
+    "fieldId": "numberField_xxx",
+    "behavior": "READONLY",
+    "roles": ["member"]
+  }
+]
+```
+
+**behavior 取值**：
+
+| 值 | 说明 |
+|---|------|
+| `NORMAL` | 正常（可见可编辑） |
+| `READONLY` | 只读（可见不可编辑） |
+| `HIDDEN` | 隐藏（不可见） |
+| `MASKED` | 脱敏展示 |
+
+#### 数据权限 JSON 格式
+
+```json
+{
+  "role": "member",
+  "dataRange": "SELF",
+  "customRule": null
+}
+```
+
+**dataRange 取值**：
+
+| 值 | 说明 | 是否支持 |
+|---|------|---------|
+| `ALL` | 全部数据 | ✅ |
+| `SELF` / `ORIGINATOR` | 本人提交的数据 | ✅ |
+| `DEPARTMENT` / `ORIGINATOR_DEPARTMENT` | 本部门提交的数据 | ✅ |
+| `SAME_LEVEL_DEPARTMENT` | 同级部门提交的数据 | ✅ |
+| `SUBORDINATE_DEPARTMENT` | 下级部门提交的数据 | ✅ |
+| `FREE_LOGIN` | 免登提交的数据 | ✅ |
+| `CUSTOM_DEPARTMENT` | 自定义部门 | ❌ 暂不支持 |
+| `FORMULA` / `CUSTOM` | 自定义过滤条件 | ❌ 暂不支持 |
+
+#### 操作权限 JSON 格式
+
+```json
+{
+  "role": "member",
+  "actions": {
+    "create": true,
+    "view": true,
+    "edit": false,
+    "delete": false,
+    "export": false
+  }
+}
+```
+
+## 前置依赖
+
+- Node.js
+- 项目根目录存在 `.cache/cookies.json`（首次运行会自动触发扫码登录）
+
+## 调用流程
+
+1. 读取项目根目录的 `.cache/cookies.json` 获取登录态；若不存在则自动触发扫码登录
+2. 调用对应接口进行权限查询或保存
+3. 根据响应体 `errorCode` 自动处理异常（csrf 过期自动刷新、登录过期自动重新登录）
+4. 返回操作结果
+
+## 文件结构
+
+```
+yida-form-permission/
+├── SKILL.md                          # 本文档
+└── scripts/
+    ├── get-permission.js             # 权限配置查询脚本
+    └── save-permission.js            # 权限配置保存脚本
+```
+
+## 接口说明
+
+### getFormPermission（获取表单权限配置）
+
+- **地址**：`GET /dingtalk/web/{appType}/query/formdesign/getFormPermission.json`
+- **参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `_api` | String | 是 | `Form.getFormPermission` |
+| `formUuid` | String | 是 | 表单 UUID |
+| `_csrf_token` | String | 是 | CSRF Token |
+
+- **返回值**：包含 `fieldPermissions`、`dataPermissions`、`actionPermissions` 的权限配置对象
+
+### saveFormPermission（保存表单权限配置）
+
+- **地址**：`POST /dingtalk/web/{appType}/query/formdesign/saveFormPermission.json`
+- **参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `_api` | String | 是 | `Form.saveFormPermission` |
+| `formUuid` | String | 是 | 表单 UUID |
+| `permissionConfig` | String | 是 | 权限配置 JSON |
+| `_csrf_token` | String | 是 | CSRF Token |
+
+- **返回值**：`success: true` 表示成功
+
+## 与其他技能配合
+
+- **创建表单** → 使用 `yida-create-form-page` 技能
+- **获取表单 Schema** → 使用 `yida-get-schema` 技能（获取 fieldId）
+- **页面配置** → 使用 `yida-page-config` 技能
+- **发布页面** → 使用 `yida-publish-page` 技能
+
+## 注意事项
+
+- 配置权限前，建议先通过 `yida-get-schema` 技能获取表单的字段列表和 fieldId
+- 字段权限中的 `fieldId` 必须与表单 Schema 中的字段 ID 一致
+- 临时文件写在当前工程根目录的 `.cache` 文件夹中
+
+### 当前功能限制
+
+| 功能 | 限制说明 |
+|------|---------|
+| **权限成员** | 仅支持「全部人员」（`DEFAULT`）和「管理员」（`MANAGER`），**暂不支持「权限矩阵」** |
+| **数据范围** | **暂不支持**「自定义部门」（`CUSTOM_DEPARTMENT`）和「自定义过滤条件」（`FORMULA`/`CUSTOM`） |
+| **字段权限** | **暂不支持自定义字段权限**，如需配置请通过宜搭管理后台手动操作 |

--- a/skills/yida-form-permission/scripts/get-permission.js
+++ b/skills/yida-form-permission/scripts/get-permission.js
@@ -1,0 +1,363 @@
+const https = require("https");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+// 权限接口域名
+const PERMISSION_BASE_URL = "https://www.aliwork.com";
+
+function findProjectRoot() {
+  for (const startDir of [process.cwd(), __dirname]) {
+    let currentDir = startDir;
+    while (currentDir !== path.dirname(currentDir)) {
+      if (
+        fs.existsSync(path.join(currentDir, "README.md")) ||
+        fs.existsSync(path.join(currentDir, ".git"))
+      ) {
+        return currentDir;
+      }
+      currentDir = path.dirname(currentDir);
+    }
+  }
+  return process.cwd();
+}
+
+const PROJECT_ROOT = findProjectRoot();
+const COOKIE_FILE = path.join(PROJECT_ROOT, ".cache", "cookies.json");
+
+function findLoginScript() {
+  const candidates = [
+    path.join(PROJECT_ROOT, ".claude", "skills", "yida-login", "scripts", "login.py"),
+    path.join(PROJECT_ROOT, "skills", "yida-login", "scripts", "login.py"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return candidates[0];
+}
+
+const LOGIN_SCRIPT = findLoginScript();
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error("用法: node get-permission.js <appType> <formUuid>");
+    console.error('示例: node .claude/skills/yida-form-permission/scripts/get-permission.js "APP_XXX" "FORM-XXX"');
+    process.exit(1);
+  }
+  return {
+    appType: args[0],
+    formUuid: args[1],
+  };
+}
+
+function extractInfoFromCookies(cookies) {
+  let csrfToken = null;
+  let corpId = null;
+  for (const cookie of cookies) {
+    if (cookie.name === "tianshu_csrf_token") {
+      csrfToken = cookie.value;
+    } else if (cookie.name === "tianshu_corp_user") {
+      const lastUnderscore = cookie.value.lastIndexOf("_");
+      if (lastUnderscore > 0) {
+        corpId = cookie.value.slice(0, lastUnderscore);
+      }
+    }
+  }
+  return { csrfToken, corpId };
+}
+
+function loadCookieData() {
+  if (!fs.existsSync(COOKIE_FILE)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(COOKIE_FILE, "utf-8").trim();
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    let cookieData;
+    if (Array.isArray(parsed)) {
+      cookieData = { cookies: parsed };
+    } else {
+      cookieData = parsed;
+    }
+    if (cookieData.cookies && cookieData.cookies.length > 0) {
+      const { csrfToken, corpId } = extractInfoFromCookies(cookieData.cookies);
+      if (csrfToken) cookieData.csrf_token = csrfToken;
+      if (corpId) cookieData.corp_id = corpId;
+    }
+    return cookieData;
+  } catch {
+    return null;
+  }
+}
+
+function triggerLogin() {
+  console.error("\n🔐 登录态失效，正在调用 login.py 重新登录...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}"`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 180_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const loginResult = JSON.parse(jsonLine);
+    if (!loginResult.cookies) throw new Error("登录结果缺少 cookies");
+    return loginResult;
+  } catch (err) {
+    console.error(`  ❌ 解析登录结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function refreshCsrfToken() {
+  console.error("\n🔄 csrf_token 已过期，正在刷新...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}" --refresh-csrf`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 60_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const result = JSON.parse(jsonLine);
+    if (!result.csrf_token || !result.cookies)
+      throw new Error("刷新结果缺少 csrf_token 或 cookies");
+    return result;
+  } catch (err) {
+    console.error(`  ❌ 解析刷新结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function isLoginExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    (responseJson.errorCode === "307" || responseJson.errorCode === "302")
+  );
+}
+
+function isCsrfTokenExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    responseJson.errorCode === "TIANSHU_000030"
+  );
+}
+
+/**
+ * 获取权限组列表
+ * 接口：GET /{appType}/permission/manage/listPermitPackages.json
+ * 域名：yidalogin.aliwork.com
+ */
+function listPermitPackages(cookies, appType, formUuid, csrfToken) {
+  const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  const parsedUrl = new URL(PERMISSION_BASE_URL);
+  const isHttps = parsedUrl.protocol === "https:";
+  const requestModule = isHttps ? https : http;
+
+  const queryParams = new URLSearchParams({
+    _api: "Permission.getPermitGroupList",
+    _mock: "false",
+    _csrf_token: csrfToken,
+    _locale_time_zone_offset: "28800000",
+    formUuid: formUuid,
+    packageName: "",
+    packageType: "FORM_PACKAGE_VIEW",
+    pageIndex: "1",
+    pageSize: "20",
+    appType: appType,
+    _stamp: String(Date.now()),
+  });
+
+  const requestPath = `/${appType}/permission/manage/listPermitPackages.json?${queryParams.toString()}`;
+
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "GET",
+      headers: {
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        "X-Requested-With": "XMLHttpRequest",
+        Referer: `${PERMISSION_BASE_URL}/${appType}/admin/${formUuid}/settings/permission`,
+      },
+      timeout: 30000,
+    };
+
+    const req = requestModule.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        console.error(`  HTTP 状态码: ${res.statusCode}`);
+        try {
+          const parsed = JSON.parse(data);
+          if (isLoginExpired(parsed)) {
+            resolve({ __needLogin: true });
+            return;
+          }
+          if (isCsrfTokenExpired(parsed)) {
+            resolve({ __csrfExpired: true });
+            return;
+          }
+          resolve(parsed);
+        } catch {
+          console.error(`  响应内容: ${data.substring(0, 500)}`);
+          resolve({ success: false, errorMsg: "响应非 JSON" });
+        }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("请求超时")); });
+    req.end();
+  });
+}
+
+/**
+ * 将权限组列表格式化为可读的权限配置摘要
+ */
+function formatPermissions(packages) {
+  return packages.map((pkg) => {
+    const packageName = pkg.packageName
+      ? (pkg.packageName.zh_CN || pkg.packageName.en_US || JSON.stringify(pkg.packageName))
+      : "未命名";
+    const description = pkg.description
+      ? (pkg.description.zh_CN || pkg.description.en_US || "")
+      : "";
+
+    // 解析权限成员
+    const roleMembers = (pkg.roleMembers || []).map((rm) => ({
+      roleType: rm.roleType,
+      label: rm.label,
+      roleValue: rm.roleValue,
+    }));
+
+    // 解析数据权限
+    let dataPermit = {};
+    if (pkg.dataPermit) {
+      try {
+        dataPermit = typeof pkg.dataPermit === "string" ? JSON.parse(pkg.dataPermit) : pkg.dataPermit;
+      } catch { dataPermit = {}; }
+    }
+
+    // 解析操作权限
+    let operatePermit = {};
+    if (pkg.operatePermit) {
+      try {
+        operatePermit = typeof pkg.operatePermit === "string" ? JSON.parse(pkg.operatePermit) : pkg.operatePermit;
+      } catch { operatePermit = {}; }
+    }
+
+    // 解析字段权限
+    let fieldPermit = {};
+    if (pkg.fieldPermit) {
+      try {
+        fieldPermit = typeof pkg.fieldPermit === "string" ? JSON.parse(pkg.fieldPermit) : pkg.fieldPermit;
+      } catch { fieldPermit = {}; }
+    }
+
+    return {
+      packageUuid: pkg.packageUuid,
+      packageName,
+      description,
+      packageType: pkg.packageType,
+      roleMembers,
+      dataPermit,
+      operatePermit,
+      fieldPermit,
+    };
+  });
+}
+
+async function main() {
+  const { appType, formUuid } = parseArgs();
+
+  console.error("=".repeat(50));
+  console.error("  get-permission - 宜搭表单权限配置查询工具");
+  console.error("=".repeat(50));
+  console.error(`\n  应用 ID:   ${appType}`);
+  console.error(`  表单 UUID: ${formUuid}`);
+  console.error(`  接口域名:  ${PERMISSION_BASE_URL}`);
+
+  console.error("\n🔑 Step 1: 读取登录态");
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error("  ⚠️  未找到本地登录态，触发登录...");
+    cookieData = triggerLogin();
+  }
+  let { cookies } = cookieData;
+  let csrfToken = cookieData.csrf_token;
+  console.error("  ✅ 登录态已就绪");
+
+  console.error("\n📋 Step 2: 查询权限组列表");
+  console.error("  发送 listPermitPackages 请求...");
+
+  let result = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+
+  // 处理 csrf_token 过期
+  if (result && result.__csrfExpired) {
+    cookieData = refreshCsrfToken();
+    csrfToken = cookieData.csrf_token;
+    cookies = cookieData.cookies;
+    console.error("  🔄 重新发送请求（csrf_token 已刷新）...");
+    result = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+  }
+
+  // 处理登录过期
+  if (result && result.__needLogin) {
+    cookieData = triggerLogin();
+    csrfToken = cookieData.csrf_token;
+    cookies = cookieData.cookies;
+    console.error("  🔄 重新发送请求（已重新登录）...");
+    result = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+  }
+
+  console.error("\n" + "=".repeat(50));
+  if (result && !result.__needLogin && !result.__csrfExpired) {
+    if (result.success) {
+      const packages = (result.content && result.content.formPermit) || [];
+      console.error(`  ✅ 权限配置查询成功！共 ${packages.length} 个权限组`);
+      console.error("=".repeat(50));
+
+      const formattedPermissions = formatPermissions(packages);
+      console.log(JSON.stringify({
+        success: true,
+        totalPackages: packages.length,
+        permissions: formattedPermissions,
+        message: "权限配置查询成功",
+      }, null, 2));
+    } else {
+      console.error(`  ❌ 查询失败: ${result.errorMsg || "未知错误"}`);
+      console.error("=".repeat(50));
+      console.log(JSON.stringify({
+        success: false,
+        message: result.errorMsg || "查询失败",
+        errorCode: result.errorCode,
+      }, null, 2));
+    }
+  } else {
+    console.error("  ❌ 请求失败");
+    console.error("=".repeat(50));
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(`\n❌ 查询异常: ${error.message}`);
+  process.exit(1);
+});

--- a/skills/yida-form-permission/scripts/save-permission.js
+++ b/skills/yida-form-permission/scripts/save-permission.js
@@ -1,0 +1,709 @@
+const https = require("https");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const querystring = require("querystring");
+const { execSync } = require("child_process");
+
+const CONFIG_PATH = path.resolve(findProjectRoot(), "config.json");
+
+function findProjectRoot() {
+  for (const startDir of [process.cwd(), __dirname]) {
+    let currentDir = startDir;
+    while (currentDir !== path.dirname(currentDir)) {
+      if (
+        fs.existsSync(path.join(currentDir, "README.md")) ||
+        fs.existsSync(path.join(currentDir, ".git"))
+      ) {
+        return currentDir;
+      }
+      currentDir = path.dirname(currentDir);
+    }
+  }
+  return process.cwd();
+}
+
+const CONFIG = fs.existsSync(CONFIG_PATH)
+  ? JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"))
+  : {};
+const DEFAULT_BASE_URL = CONFIG.defaultBaseUrl || "https://www.aliwork.com";
+// 权限接口域名
+const PERMISSION_BASE_URL = "https://www.aliwork.com";
+const PROJECT_ROOT = findProjectRoot();
+const COOKIE_FILE = path.join(PROJECT_ROOT, ".cache", "cookies.json");
+
+function findLoginScript() {
+  const candidates = [
+    path.join(PROJECT_ROOT, ".claude", "skills", "yida-login", "scripts", "login.py"),
+    path.join(PROJECT_ROOT, "skills", "yida-login", "scripts", "login.py"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return candidates[0];
+}
+
+const LOGIN_SCRIPT = findLoginScript();
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(
+      "用法: node save-permission.js <appType> <formUuid> [fieldPermissionsJson] [--data-permission <json>] [--action-permission <json>]"
+    );
+    console.error("");
+    console.error("示例:");
+    console.error(
+      '  字段权限: node save-permission.js APP_XXX FORM-XXX \'[{"fieldId":"textField_xxx","behavior":"HIDDEN","roles":["member"]}]\''
+    );
+    console.error(
+      '  数据权限: node save-permission.js APP_XXX FORM-XXX --data-permission \'{"role":"member","dataRange":"SELF"}\''
+    );
+    console.error(
+      '  操作权限: node save-permission.js APP_XXX FORM-XXX --action-permission \'{"role":"DEFAULT","operations":{"OPERATE_VIEW":true,"OPERATE_EDIT":false,"OPERATE_DELETE":false}}\''
+    );
+    process.exit(1);
+  }
+
+  const parsed = {
+    appType: args[0],
+    formUuid: args[1],
+    fieldPermissions: null,
+    dataPermission: null,
+    actionPermission: null,
+  };
+
+  let index = 2;
+  while (index < args.length) {
+    if (args[index] === "--data-permission" && args[index + 1]) {
+      parsed.dataPermission = parseJsonArg(args[index + 1], "data-permission");
+      index += 2;
+    } else if (args[index] === "--action-permission" && args[index + 1]) {
+      parsed.actionPermission = parseJsonArg(args[index + 1], "action-permission");
+      index += 2;
+    } else if (!parsed.fieldPermissions) {
+      parsed.fieldPermissions = parseJsonArg(args[index], "fieldPermissions");
+      index += 1;
+    } else {
+      index += 1;
+    }
+  }
+
+  if (!parsed.fieldPermissions && !parsed.dataPermission && !parsed.actionPermission) {
+    console.error("❌ 至少需要提供一种权限配置（字段权限/数据权限/操作权限）");
+    process.exit(1);
+  }
+
+  return parsed;
+}
+
+function parseJsonArg(jsonStr, paramName) {
+  if (fs.existsSync(jsonStr)) {
+    try {
+      return JSON.parse(fs.readFileSync(jsonStr, "utf-8"));
+    } catch (err) {
+      console.error(`❌ 解析 ${paramName} 文件失败: ${err.message}`);
+      process.exit(1);
+    }
+  }
+  try {
+    return JSON.parse(jsonStr);
+  } catch (err) {
+    console.error(`❌ 解析 ${paramName} JSON 失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function validateFieldPermissions(fieldPermissions) {
+  if (!Array.isArray(fieldPermissions)) {
+    throw new Error("字段权限必须是数组格式");
+  }
+  const validBehaviors = ["NORMAL", "READONLY", "HIDDEN", "MASKED"];
+  for (const permission of fieldPermissions) {
+    if (!permission.fieldId) {
+      throw new Error("每个字段权限必须包含 fieldId");
+    }
+    if (permission.behavior && !validBehaviors.includes(permission.behavior)) {
+      throw new Error(
+        `无效的 behavior: ${permission.behavior}，有效值: ${validBehaviors.join(", ")}`
+      );
+    }
+  }
+}
+
+function validateDataPermission(dataPermission) {
+  const validRanges = [
+    // 用户友好别名
+    "ALL", "SELF", "DEPARTMENT", "CUSTOM",
+    // 接口原始值
+    "ORIGINATOR", "ORIGINATOR_DEPARTMENT",
+    "SAME_LEVEL_DEPARTMENT", "SUBORDINATE_DEPARTMENT",
+    "FREE_LOGIN", "CUSTOM_DEPARTMENT", "FORMULA",
+  ];
+  if (dataPermission.dataRange && !validRanges.includes(dataPermission.dataRange)) {
+    throw new Error(
+      `无效的 dataRange: ${dataPermission.dataRange}，有效值: ${validRanges.join(", ")}`
+    );
+  }
+}
+
+// 所有支持的操作权限 key（来自宜搭接口实际值）
+const VALID_OPERATE_KEYS = [
+  "OPERATE_VIEW",              // 查看
+  "OPERATE_EDIT",              // 编辑
+  "OPERATE_DELETE",            // 删除
+  "OPERATE_HISTORY",           // 变更记录
+  "OPERATE_COMMENT",           // 评论
+  "OPERATE_PRINT",             // 打印
+  "OPERATE_BATCH_IMPORT",      // 批量导入
+  "OPERATE_BATCH_EXPORT",      // 批量导出
+  "OPERATE_BATCH_EDIT",        // 批量修改
+  "OPERATE_BATCH_DELETE",      // 批量删除
+  "OPERATE_BATCH_PRINT",       // 批量打印
+  "OPERATE_BATCH_DOWNLOAD",    // 批量下载文件
+  "OPERATE_BATCH_DOWNLOAD_QRCODE", // 批量下载二维码
+  "OPERATE_CREATE",            // 新增（提交）
+];
+
+function validateActionPermission(actionPermission) {
+  if (!actionPermission.operations || typeof actionPermission.operations !== "object") {
+    throw new Error(
+      "操作权限必须包含 operations 对象，格式为 {\"OPERATE_VIEW\": true, \"OPERATE_EDIT\": false, ...}"
+    );
+  }
+  for (const key of Object.keys(actionPermission.operations)) {
+    if (!VALID_OPERATE_KEYS.includes(key)) {
+      throw new Error(
+        `无效的操作权限 key: ${key}，有效值: ${VALID_OPERATE_KEYS.join(", ")}`
+      );
+    }
+  }
+}
+
+function extractInfoFromCookies(cookies) {
+  let csrfToken = null;
+  let corpId = null;
+  for (const cookie of cookies) {
+    if (cookie.name === "tianshu_csrf_token") {
+      csrfToken = cookie.value;
+    } else if (cookie.name === "tianshu_corp_user") {
+      const lastUnderscore = cookie.value.lastIndexOf("_");
+      if (lastUnderscore > 0) {
+        corpId = cookie.value.slice(0, lastUnderscore);
+      }
+    }
+  }
+  return { csrfToken, corpId };
+}
+
+function loadCookieData() {
+  if (!fs.existsSync(COOKIE_FILE)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(COOKIE_FILE, "utf-8").trim();
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    let cookieData;
+    if (Array.isArray(parsed)) {
+      cookieData = { cookies: parsed, base_url: DEFAULT_BASE_URL };
+    } else {
+      cookieData = parsed;
+    }
+    if (cookieData.cookies && cookieData.cookies.length > 0) {
+      const { csrfToken, corpId } = extractInfoFromCookies(cookieData.cookies);
+      if (csrfToken) cookieData.csrf_token = csrfToken;
+      if (corpId) cookieData.corp_id = corpId;
+    }
+    return cookieData;
+  } catch {
+    return null;
+  }
+}
+
+function triggerLogin() {
+  console.error("\n🔐 登录态失效，正在调用 login.py 重新登录...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}"`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 180_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const loginResult = JSON.parse(jsonLine);
+    if (!loginResult.cookies) throw new Error("登录结果缺少 cookies");
+    return loginResult;
+  } catch (err) {
+    console.error(`  ❌ 解析登录结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function resolveBaseUrl(cookieData) {
+  return ((cookieData && cookieData.base_url) || DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function isLoginExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    (responseJson.errorCode === "307" || responseJson.errorCode === "302")
+  );
+}
+
+function isCsrfTokenExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    responseJson.errorCode === "TIANSHU_000030"
+  );
+}
+
+function refreshCsrfToken() {
+  console.error("\n🔄 csrf_token 已过期，正在刷新...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}" --refresh-csrf`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 60_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const result = JSON.parse(jsonLine);
+    if (!result.csrf_token || !result.cookies)
+      throw new Error("刷新结果缺少 csrf_token 或 cookies");
+    return result;
+  } catch (err) {
+    console.error(`  ❌ 解析刷新结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function sendPostRequest(baseUrl, cookies, requestPath, postData) {
+  return new Promise((resolve, reject) => {
+    const cookieHeader = cookies
+      .map((cookie) => `${cookie.name}=${cookie.value}`)
+      .join("; ");
+
+    const parsedUrl = new URL(baseUrl);
+    const isHttps = parsedUrl.protocol === "https:";
+    const requestModule = isHttps ? https : http;
+
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "POST",
+      headers: {
+        Origin: baseUrl,
+        Referer: baseUrl + "/",
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "x-requested-with": "XMLHttpRequest",
+      },
+      timeout: 30000,
+    };
+
+    const request = requestModule.request(requestOptions, (response) => {
+      let responseData = "";
+      response.on("data", (chunk) => {
+        responseData += chunk;
+      });
+      response.on("end", () => {
+        console.error(`  HTTP 状态码: ${response.statusCode}`);
+        let parsed;
+        try {
+          parsed = JSON.parse(responseData);
+        } catch (parseError) {
+          console.error(`  响应内容: ${responseData.substring(0, 500)}`);
+          resolve({
+            success: false,
+            errorMsg: `HTTP ${response.statusCode}: 响应非 JSON`,
+          });
+          return;
+        }
+        if (isLoginExpired(parsed)) {
+          console.error(`  检测到登录过期: ${parsed.errorMsg}`);
+          resolve({ __needLogin: true });
+          return;
+        }
+        if (isCsrfTokenExpired(parsed)) {
+          console.error(`  检测到 csrf_token 过期: ${parsed.errorMsg}`);
+          resolve({ __csrfExpired: true });
+          return;
+        }
+        resolve(parsed);
+      });
+    });
+
+    request.on("timeout", () => {
+      console.error("  ❌ 请求超时");
+      request.destroy();
+      reject(new Error("请求超时"));
+    });
+
+    request.on("error", (requestError) => {
+      reject(requestError);
+    });
+
+    request.write(postData);
+    request.end();
+  });
+}
+
+// 数据权限范围映射：用户友好的 dataRange 值 -> 接口实际使用的 type 值
+// 同时也支持直接传入接口原始值（如 ORIGINATOR_DEPARTMENT）
+const DATA_RANGE_TO_PERMIT_TYPE = {
+  // 用户友好别名
+  ALL: "ALL",                                       // 全部数据
+  SELF: "ORIGINATOR",                               // 本人提交（别名）
+  DEPARTMENT: "ORIGINATOR_DEPARTMENT",              // 本部门提交（别名）
+  CUSTOM: "FORMULA",                                // 自定义过滤条件（别名）
+  // 接口原始值（直接透传）
+  ORIGINATOR: "ORIGINATOR",                         // 本人提交
+  ORIGINATOR_DEPARTMENT: "ORIGINATOR_DEPARTMENT",   // 本部门提交
+  SAME_LEVEL_DEPARTMENT: "SAME_LEVEL_DEPARTMENT",   // 同级部门提交
+  SUBORDINATE_DEPARTMENT: "SUBORDINATE_DEPARTMENT", // 下级部门提交
+  FREE_LOGIN: "FREE_LOGIN",                         // 免登提交
+  CUSTOM_DEPARTMENT: "CUSTOM_DEPARTMENT",           // 自定义部门
+  FORMULA: "FORMULA",                               // 自定义过滤条件
+};
+
+function buildPermissionConfig(fieldPermissions, dataPermission, actionPermission) {
+  const config = {};
+
+  if (fieldPermissions) {
+    config.fieldPermissions = fieldPermissions.map((permission) => ({
+      fieldId: permission.fieldId,
+      behavior: permission.behavior || "NORMAL",
+      roles: permission.roles || ["all"],
+    }));
+  }
+
+  if (dataPermission) {
+    config.dataPermissions = [
+      {
+        role: dataPermission.role || "member",
+        dataRange: dataPermission.dataRange || "ALL",
+        customRule: dataPermission.customRule || null,
+      },
+    ];
+  }
+
+  if (actionPermission) {
+    config.actionPermissions = [
+      {
+        role: actionPermission.role || "member",
+        actions: {
+          create: actionPermission.actions.create !== false,
+          view: actionPermission.actions.view !== false,
+          edit: actionPermission.actions.edit !== false,
+          delete: actionPermission.actions.delete !== false,
+          export: actionPermission.actions.export !== false,
+        },
+      },
+    ];
+  }
+
+  return config;
+}
+
+/**
+ * 获取权限组列表
+ * 接口：GET /{appType}/permission/manage/listPermitPackages.json
+ */
+async function listPermitPackages(cookies, appType, formUuid, csrfToken) {
+  const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  const parsedUrl = new URL(PERMISSION_BASE_URL);
+  const isHttps = parsedUrl.protocol === "https:";
+  const requestModule = isHttps ? https : http;
+
+  const queryParams = new URLSearchParams({
+    _api: "Permission.getPermitGroupList",
+    _mock: "false",
+    _csrf_token: csrfToken,
+    _locale_time_zone_offset: "28800000",
+    formUuid: formUuid,
+    packageName: "",
+    packageType: "FORM_PACKAGE_VIEW",
+    pageIndex: "1",
+    pageSize: "20",
+    appType: appType,
+    _stamp: String(Date.now()),
+  });
+
+  const requestPath = `/${appType}/permission/manage/listPermitPackages.json?${queryParams.toString()}`;
+
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "GET",
+      headers: {
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        "X-Requested-With": "XMLHttpRequest",
+        Referer: `${PERMISSION_BASE_URL}/${appType}/admin/${formUuid}/settings/permission`,
+      },
+      timeout: 30000,
+    };
+
+    const req = requestModule.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch {
+          resolve({ success: false, errorMsg: "响应非 JSON" });
+        }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("请求超时")); });
+    req.end();
+  });
+}
+
+/**
+ * 保存单个权限组
+ * 接口：POST /{appType}/permission/manage/saveOrUpdatePermit.json
+ */
+async function savePermitPackage(cookies, appType, formUuid, csrfToken, permitPackage) {
+  const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  const parsedUrl = new URL(PERMISSION_BASE_URL);
+  const isHttps = parsedUrl.protocol === "https:";
+  const requestModule = isHttps ? https : http;
+
+  const requestPath = `/${appType}/permission/manage/saveOrUpdatePermit.json?_api=Permission.saveOrUpdatePermitGroup&_mock=false&_stamp=${Date.now()}`;
+
+  const postParams = {
+    _csrf_token: csrfToken,
+    _locale_time_zone_offset: "28800000",
+    formUuid: formUuid,
+    packageType: permitPackage.packageType || "FORM_PACKAGE_VIEW",
+    packageName: JSON.stringify(permitPackage.packageName),
+    description: JSON.stringify(permitPackage.description),
+    roleData: JSON.stringify({
+      include: (permitPackage.roleMembers || []).map((rm) => {
+        // roleValue 可能是字符串（如 "ALL"）或数组（如 [{key: "xxx"}]）
+        let roleValue;
+        if (typeof rm.roleValue === "string") {
+          roleValue = rm.roleValue || "ALL";
+        } else if (Array.isArray(rm.roleValue) && rm.roleValue.length > 0) {
+          roleValue = rm.roleValue.map((rv) => rv.key).join(",");
+        } else {
+          roleValue = "ALL";
+        }
+        return { label: rm.label, roleType: rm.roleType, roleValue };
+      }),
+    }),
+    dataPermit: permitPackage.dataPermit,
+    operatePermit: permitPackage.operatePermit,
+    customButtonPermit: permitPackage.customButtonPermit || "[]",
+    fieldPermit: permitPackage.fieldPermit,
+    packageUuid: permitPackage.packageUuid,
+    viewData: permitPackage.viewData,
+  };
+
+  const postData = querystring.stringify(postParams);
+
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": Buffer.byteLength(postData),
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        Origin: PERMISSION_BASE_URL,
+        Referer: `${PERMISSION_BASE_URL}/${appType}/admin/${formUuid}/settings/permission`,
+        "X-Requested-With": "XMLHttpRequest",
+      },
+      timeout: 30000,
+    };
+
+    const req = requestModule.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch {
+          resolve({ success: false, errorMsg: "响应非 JSON" });
+        }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("请求超时")); });
+    req.write(postData);
+    req.end();
+  });
+}
+
+async function main() {
+  const { appType, formUuid, fieldPermissions, dataPermission, actionPermission } =
+    parseArgs();
+
+  console.error("=".repeat(50));
+  console.error("  save-permission - 宜搭表单权限配置保存工具");
+  console.error("=".repeat(50));
+  console.error(`\n  应用 ID:   ${appType}`);
+  console.error(`  表单 UUID: ${formUuid}`);
+
+  console.error("\n📋 Step 0: 验证参数");
+  try {
+    if (fieldPermissions) {
+      validateFieldPermissions(fieldPermissions);
+      console.error(`  ✅ 字段权限验证通过（${fieldPermissions.length} 条规则）`);
+    }
+    if (dataPermission) {
+      validateDataPermission(dataPermission);
+      console.error(`  ✅ 数据权限验证通过（${dataPermission.dataRange || "ALL"}）`);
+    }
+    if (actionPermission) {
+      validateActionPermission(actionPermission);
+      console.error("  ✅ 操作权限验证通过");
+    }
+  } catch (err) {
+    console.error(`  ❌ 参数验证失败: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.error("\n🔑 Step 1: 读取登录态");
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error("  ⚠️  未找到本地登录态，触发登录...");
+    cookieData = triggerLogin();
+  }
+  let { cookies } = cookieData;
+  let csrfToken = cookieData.csrf_token;
+  console.error(`  ✅ 登录态已就绪（接口域名: ${PERMISSION_BASE_URL}）`);
+
+  // 数据权限和操作权限都走新接口（先获取权限组列表，再逐个更新）
+  if (dataPermission || actionPermission) {
+    console.error("\n📋 Step 2: 获取当前权限组列表");
+    const listResult = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+
+    if (!listResult.success) {
+      console.error(`  ❌ 获取权限组失败: ${listResult.errorMsg}`);
+      process.exit(1);
+    }
+
+    const packages = listResult.content && listResult.content.formPermit;
+    if (!packages || packages.length === 0) {
+      console.error("  ⚠️  未找到任何权限组");
+      process.exit(1);
+    }
+    console.error(`  ✅ 获取到 ${packages.length} 个权限组`);
+
+    // 根据 role 筛选要更新的权限组
+    const targetRole = (dataPermission || actionPermission).role || "DEFAULT";
+    const packagesToUpdate = packages.filter((pkg) => {
+      if (targetRole === "DEFAULT") {
+        return pkg.roleMembers && pkg.roleMembers.some((rm) => rm.roleType === "DEFAULT");
+      }
+      if (targetRole === "MANAGER") {
+        return pkg.roleMembers && pkg.roleMembers.some((rm) => rm.roleType === "MANAGER");
+      }
+      return true;
+    });
+
+    if (packagesToUpdate.length === 0) {
+      console.error(`  ⚠️  未找到匹配角色 "${targetRole}" 的权限组`);
+      process.exit(1);
+    }
+
+    console.error(`  将更新 ${packagesToUpdate.length} 个权限组`);
+
+    // 准备数据权限的 permitType
+    let permitType = null;
+    if (dataPermission) {
+      permitType = DATA_RANGE_TO_PERMIT_TYPE[dataPermission.dataRange] || dataPermission.dataRange;
+      console.error(`\n💾 Step 3: 更新权限组（数据权限: ${dataPermission.dataRange} → ${permitType}${actionPermission ? "，操作权限: 同步更新" : ""}）`);
+    } else {
+      console.error(`\n💾 Step 3: 更新权限组操作权限`);
+    }
+
+    let allSuccess = true;
+    for (const pkg of packagesToUpdate) {
+      const pkgName = pkg.packageName && (pkg.packageName.zh_CN || pkg.packageName.en_US);
+      console.error(`  → 更新权限组: ${pkgName} (${pkg.packageUuid})`);
+
+      const updatedPkg = { ...pkg };
+
+      // 更新数据权限
+      if (dataPermission) {
+        updatedPkg.dataPermit = JSON.stringify({ rule: [{ type: permitType, value: "y" }] });
+      }
+
+      // 更新操作权限：将 {OPERATE_VIEW: true, OPERATE_EDIT: false} 转为 {"OPERATE_VIEW":"y"} 格式
+      if (actionPermission) {
+        const currentOperatePermit = pkg.operatePermit
+          ? (typeof pkg.operatePermit === "string" ? JSON.parse(pkg.operatePermit) : pkg.operatePermit)
+          : {};
+        const newOperatePermit = { ...currentOperatePermit };
+        for (const [key, enabled] of Object.entries(actionPermission.operations)) {
+          if (enabled) {
+            newOperatePermit[key] = "y";
+          } else {
+            delete newOperatePermit[key];
+          }
+        }
+        updatedPkg.operatePermit = JSON.stringify(newOperatePermit);
+      }
+
+      const saveResult = await savePermitPackage(cookies, appType, formUuid, csrfToken, updatedPkg);
+
+      if (saveResult && saveResult.success) {
+        console.error(`    ✅ 更新成功`);
+      } else {
+        console.error(`    ❌ 更新失败: ${saveResult && saveResult.errorMsg}`);
+        allSuccess = false;
+      }
+    }
+
+    console.error("\n" + "=".repeat(50));
+    if (allSuccess) {
+      console.error("  ✅ 权限配置保存成功！");
+      console.error("=".repeat(50));
+      const summary = {};
+      if (dataPermission) summary.dataPermission = `数据范围: ${dataPermission.dataRange}`;
+      if (actionPermission) summary.actionPermission = `操作权限: ${Object.keys(actionPermission.operations).join(", ")}`;
+      console.log(JSON.stringify({ success: true, summary, message: "权限配置已保存" }, null, 2));
+    } else {
+      console.error("  ❌ 部分权限组更新失败");
+      console.error("=".repeat(50));
+      process.exit(1);
+    }
+    return;
+  }
+
+  // 字段权限暂不支持（原接口已失效，需要进一步探索）
+  if (fieldPermissions) {
+    console.error("\n⚠️  注意：字段权限的配置接口尚未验证，当前仅支持数据权限和操作权限配置。");
+    console.error("  如需配置字段权限，请通过宜搭管理后台手动操作。");
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(`\n❌ 保存异常: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## 新增宜搭表单权限配置技能

关联 Issue openyida/openyida#105

### 功能说明

新增 `yida-form-permission` 技能，支持查询和配置宜搭表单的权限。

### 包含文件

- `skills/yida-form-permission/SKILL.md`：技能说明文档
- `skills/yida-form-permission/scripts/get-permission.js`：查询表单权限配置
- `skills/yida-form-permission/scripts/save-permission.js`：保存表单权限配置

### 支持功能

- ✅ 查询权限组列表（`listPermitPackages` 接口）
- ✅ 配置数据权限（支持 8 种数据范围：ALL / ORIGINATOR / ORIGINATOR_DEPARTMENT / SAME_LEVEL_DEPARTMENT / SUBORDINATE_DEPARTMENT / FREE_LOGIN / CUSTOM_DEPARTMENT / FORMULA）
- ✅ 配置操作权限（支持 14 种操作类型：新增/查看/编辑/删除/导出等）
- ⚠️ 字段权限（接口层面支持，但宜搭平台字段权限功能暂不稳定）

### 使用示例

```bash
# 查询权限配置
node .claude/skills/yida-form-permission/scripts/get-permission.js APP_XXX FORM-XXX

# 配置数据权限（仅本人可见）
node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX --data-permission '{"role":"member","dataRange":"ORIGINATOR"}'

# 配置操作权限（禁止删除和导出）
node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX --action-permission '{"role":"member","actions":{"create":true,"view":true,"edit":true,"delete":false,"export":false}}'
```