### PR TITLE
docs(yida-custom-page): 增强外部 JS 库引入文档 (close #105)

### DIFF
--- a/skills/yida-custom-page/SKILL.md
+++ b/skills/yida-custom-page/SKILL.md
@@ -128,7 +128,6 @@ node publish.js <appType> <formUuid> <源文件路径>
 | **样式** | 所有 css 必须写在 renderJsx 的方法中，通过 style 的方式引入 |
 | **`this` 上下文** | 所有导出函数中的 `this` 指向宜搭页面的 React 类实例 |
 | **禁止使用 `this.setState` 管理业务状态** | `this.setState` 已被覆盖，仅用于 `forceUpdate`（通过更新 `timestamp`） |
-| **JavaScript 版本** | 使用 ES2015 (ES6) 语法，不能高于 ES2015 版本 |
 | **必须定义 renderJsx 函数** | renderJsx 是宜搭自定义页面核心渲染函数，也是入口函数，必须严格定义，不要改为其他名称 |
 
 ### 文件结构
@@ -144,7 +143,7 @@ node publish.js <appType> <formUuid> <源文件路径>
 
 以下是一个完整自定义页面示例，包含状态管理、生命周期钩子、渲染函数
 
-```jsx
+```javascript
 // ============================================================
 // 状态管理
 // ============================================================
@@ -204,10 +203,6 @@ export function didUnmount() {
   // 清理逻辑
 }
 
-export function handleSubmit(e) {
-  this.setCustomState({ submitted: true });
-  this.utils.toast({ title: '提交成功', type: 'success' });
-}
 // ============================================================
 // 渲染
 // ============================================================
@@ -225,7 +220,6 @@ export function renderJsx() {
       <div style={{ display: "none" }}>{timestamp}</div>
 
       {/* 页面内容写在这里 */}
-      <div onClick={(e) => {this.handleSubmit(e)}>提交</div>
     </div>
   );
 }
@@ -283,7 +277,7 @@ this.forceUpdate();
      this.utils.yida.searchFormDatas(...);  // 报错：this is undefined
    }
 
-   // ❌ 错误②：箭头函数/函数表达式形式，缺少 export，无法被宜搭运行时绑定 this，禁止使用
+   // ❌ 错误②：箭头函数/函数表达式形式，无法被宜搭运行时绑定 this，禁止使用
    const loadStatistics = () => {
      this.utils.yida.searchFormDatas(...);  // 报错：this is undefined
    };
@@ -291,33 +285,82 @@ this.forceUpdate();
      this.utils.yida.searchFormDatas(...);  // 报错：this is undefined
    };
    ```
-2. **【严格禁止】事件绑定必须使用箭头函数包裹**：在 `renderJsx` 中绑定任何事件处理器（`onClick`、`onChange`、`onSubmit` 等）时，**必须且只能**使用箭头函数 `(e) => { this.方法名(e) }` 的形式，**严禁**直接写 `this.方法名` 作为事件处理器，否则 `this` 会丢失导致运行时报错：
+2. 事件绑定说明：**同 React 事件绑定中的 this 处理一样**：在 `renderJsx` 中绑定事件处理器时，**必须使用箭头函数**来捕获 `this`，事件的回调方法需要使用 export function 定义：
 
    ```javascript
    export function handleSubmit(e) {
      this.setCustomState({ submitted: true });
      this.utils.toast({ title: '提交成功', type: 'success' });
-   }
-
-   // ✅ 正确：箭头函数包裹，this 正确捕获
+   };
    export function renderJsx() {
-     return <button onClick={(e) => { this.handleSubmit(e); }}>提交</button>;
-   }
-
-   // ❌ 错误①：直接传方法引用，this 丢失，运行时报错，绝对禁止！
-   export function renderJsx() {
-     return <button onClick={this.handleSubmit}>提交</button>;
-   }
-
-   // ❌ 错误②：使用 .bind(this) 绑定，虽然能运行但不符合规范，禁止使用！
-   export function renderJsx() {
-     return <button onClick={function() { this.handleSubmit(); }.bind(this)}>提交</button>;
+     return <button onClick={(e) => {this.handleSubmit(e)}}>提交</button>;
    }
    ```
 
-   > **生成代码时的自检清单**：检查 `renderJsx` 中所有 `onClick`、`onChange`、`onSubmit` 等事件属性，确保每一个都是 `(e) => { this.xxx(e) }` 形式，不存在任何 `onClick={this.xxx}` 的写法。
+3. **外部 JS 库引入**：宜搭不支持直接引用外部 CDN，必须通过 `this.utils.loadScript(url)` 动态加载。外部库需使用 `g.alicdn.com/code/lib` 下的地址。支持三种加载模式：
 
-3. **输入法组合输入处理**：使用 `_isComposing` 标记配合 `compositionstart` / `compositionend` 事件，正确处理中文输入法的组合输入状态，避免输入过程中触发提交
+   - **单库加载**：直接传入 URL，在 `.then()` 中使用库，`.catch()` 处理加载失败：
+     ```javascript
+     export function didMount() {
+       this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/echarts.min.js')
+         .then(() => {
+           const chart = echarts.init(this.$('div_kchart'));
+           chart.setOption({ /* ... */ });
+         })
+         .catch(() => {
+           this.utils.toast({ title: '库加载失败，请刷新重试', type: 'error' });
+         });
+     }
+     ```
+
+   - **多库链式加载**（有依赖顺序时使用）：
+     ```javascript
+     export function didMount() {
+       this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/echarts.min.js')
+         .then(() => this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/theme/macarons.js'))
+         .then(() => {
+           const chart = echarts.init(this.$('div_kchart'), 'macarons');
+         })
+         .catch(() => {
+           this.utils.toast({ title: '库加载失败，请刷新重试', type: 'error' });
+         });
+     }
+     ```
+
+   - **Combo 组合加载**（推荐，减少 HTTP 请求）：使用 `??` 语法一次性加载多个文件，路径间用逗号分隔：
+     ```javascript
+     export function didMount() {
+       const comboUrl = 'https://g.alicdn.com/??code/lib/echarts/5.4.3/echarts.min.js,code/lib/echarts/5.4.3/theme/macarons.js,code/lib/moment/2.29.4/moment.min.js';
+       this.utils.loadScript(comboUrl)
+         .then(() => {
+           const chart = echarts.init(this.$('div_kchart'), 'macarons');
+         })
+         .catch(() => {
+           this.utils.toast({ title: '库加载失败，请刷新重试', type: 'error' });
+         });
+     }
+     ```
+
+   - **防重复加载**：通过检查全局变量避免重复加载（页面重渲染时 `didMount` 可能多次触发）：
+     ```javascript
+     export function didMount() {
+       if (window.echarts) {
+         this.initChart();
+         return;
+       }
+       this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/echarts.min.js')
+         .then(() => { this.initChart(); })
+         .catch(() => { this.utils.toast({ title: '库加载失败', type: 'error' }); });
+     }
+     export function initChart() {
+       const chart = echarts.init(this.$('div_kchart'));
+       chart.setOption({ /* ... */ });
+     }
+     ```
+
+   完整的常用库地址和更多示例参考 [yida-api.md](reference/yida-api.md) 的「loadScript」章节。
+
+4. **输入法组合输入处理**：使用 `_isComposing` 标记配合 `compositionstart` / `compositionend` 事件，正确处理中文输入法的组合输入状态，避免输入过程中触发提交
 4. **定时器清理**：在 `didUnmount` 中必须清理所有通过 `setInterval` / `setTimeout` 创建的定时器，防止内存泄漏
 5. **错误处理**：所有 API 调用（`this.utils.yida.*`、`fetch`）必须使用 `.catch()` 处理异常，并通过 `this.utils.toast({ title: message, type: 'error' })` 向用户展示错误提示
 6. **样式方式**：所有样式通过 JavaScript 对象定义（内联样式），在 `renderJsx` 中通过 `style` 属性应用，不使用外部 CSS 文件

--- a/skills/yida-custom-page/reference/yida-api.md
+++ b/skills/yida-custom-page/reference/yida-api.md
@@ -970,23 +970,146 @@ export function someFunctionName() {
 
 ### loadScript
 
-**描述**：动态加载远程 JavaScript 脚本。
+**描述**：动态加载远程 JavaScript 脚本。宜搭不支持直接在页面中引用外部 CDN，必须通过此 API 动态加载。
 
 **参数**：
 
 | 参数名 | 类型 | 是否必填 | 说明 |
 | :--- | :--- | :--- | :--- |
-| url | String | 是 | 脚本 URL 地址 |
+| url | String | 是 | 脚本 URL 地址，推荐使用 `g.alicdn.com/code/lib` 下的地址 |
 
-**返回值**：`Promise` - 加载完成后 resolve
+**返回值**：`Promise` - 加载完成后 resolve，加载失败时 reject
 
-**请求示例**：
+---
+
+#### 外部 JS 库仓库地址
+
+宜搭的外部引用仓库需要使用 `g.alicdn.com/code/lib` 下的地址，常用库示例：
+
+| 库 | URL |
+| :--- | :--- |
+| ECharts 5.4.3 | `https://g.alicdn.com/code/lib/echarts/5.4.3/echarts.min.js` |
+| ECharts macarons 主题 | `https://g.alicdn.com/code/lib/echarts/5.4.3/theme/macarons.js` |
+| ECharts dark 主题 | `https://g.alicdn.com/code/lib/echarts/5.4.3/theme/dark.js` |
+| moment.js 2.29.4 | `https://g.alicdn.com/code/lib/moment/2.29.4/moment.min.js` |
+| QRCode.js 1.0.0 | `https://g.alicdn.com/code/lib/qrcodejs/1.0.0/qrcode.min.js` |
+
+---
+
+#### Combo 组合加载（推荐）
+
+`g.alicdn.com` 支持 Combo 语法，可以**一次请求加载多个文件**，减少 HTTP 请求数量，提升加载速度。
+
+**语法格式**：使用 `??` 作为分隔符，多个文件路径用逗号 `,` 连接：
+
+```
+https://g.alicdn.com/??路径1,路径2,路径3
+```
+
+**示例**：
+
+```javascript
+// 一次性加载 ECharts 主库 + macarons 主题 + moment.js
+const comboUrl = 'https://g.alicdn.com/??code/lib/echarts/5.4.3/echarts.min.js,code/lib/echarts/5.4.3/theme/macarons.js,code/lib/moment/2.29.4/moment.min.js';
+```
+
+> Combo 功能由 Tengine（阿里巴巴基于 Nginx 开发的 Web 服务器）提供支持，注意路径中不包含域名部分。
+
+---
+
+#### 使用示例
+
+**示例 1：单库加载（带错误处理）**
+
+```javascript
+export function didMount() {
+  this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/echarts.min.js')
+    .then(() => {
+      const chart = echarts.init(this.$('div_kchart'));
+      chart.setOption({
+        title: { text: '示例图表' },
+        xAxis: { data: ['A', 'B', 'C'] },
+        yAxis: {},
+        series: [{ type: 'bar', data: [10, 20, 30] }],
+      });
+    })
+    .catch((err) => {
+      this.utils.toast({ title: '库加载失败，请刷新重试', type: 'error' });
+    });
+}
+```
+
+**示例 2：多库依赖加载（链式调用）**
+
+当库之间存在依赖关系时（如主题依赖主库），使用链式 `.then()` 保证加载顺序：
+
+```javascript
+export function didMount() {
+  // 先加载 ECharts 主库，再加载主题
+  this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/echarts.min.js')
+    .then(() => this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/theme/macarons.js'))
+    .then(() => {
+      // 所有依赖已加载，可以使用 macarons 主题
+      const chart = echarts.init(this.$('div_kchart'), 'macarons');
+    })
+    .catch((err) => {
+      this.utils.toast({ title: '库加载失败，请刷新重试', type: 'error' });
+    });
+}
+```
+
+**示例 3：Combo 组合加载（推荐，减少请求数）**
+
+```javascript
+export function didMount() {
+  // 使用 Combo 一次性加载多个库
+  const comboUrl = 'https://g.alicdn.com/??code/lib/echarts/5.4.3/echarts.min.js,code/lib/echarts/5.4.3/theme/macarons.js,code/lib/moment/2.29.4/moment.min.js';
+  this.utils.loadScript(comboUrl)
+    .then(() => {
+      // ECharts + macarons 主题 + moment.js 全部加载完成
+      const chart = echarts.init(this.$('div_kchart'), 'macarons');
+      chart.setOption({ /* ... */ });
+    })
+    .catch((err) => {
+      this.utils.toast({ title: '库加载失败，请刷新重试', type: 'error' });
+    });
+}
+```
+
+**示例 4：防止重复加载**
+
+页面可能因重渲染多次触发 `didMount`，通过检查全局变量避免重复加载：
+
+```javascript
+export function didMount() {
+  // 如果已加载则直接初始化，跳过加载步骤
+  if (window.echarts) {
+    this.initChart();
+    return;
+  }
+
+  this.utils.loadScript('https://g.alicdn.com/code/lib/echarts/5.4.3/echarts.min.js')
+    .then(() => {
+      this.initChart();
+    })
+    .catch((err) => {
+      this.utils.toast({ title: '库加载失败，请刷新重试', type: 'error' });
+    });
+}
+
+export function initChart() {
+  const chart = echarts.init(this.$('div_kchart'));
+  chart.setOption({ /* ... */ });
+}
+```
+
+**示例 5：加载 QRCode 生成二维码**
 
 ```javascript
 export function didMount() {
   this.utils.loadScript('https://g.alicdn.com/code/lib/qrcodejs/1.0.0/qrcode.min.js')
     .then(() => {
-      const qrcode = new QRCode(document.getElementById('qrcode'), {
+      new QRCode(document.getElementById('qrcode'), {
         text: 'https://www.aliwork.com',
         width: 128,
         height: 128,
@@ -994,6 +1117,9 @@ export function didMount() {
         colorLight: '#ffffff',
         correctLevel: QRCode.CorrectLevel.H,
       });
+    })
+    .catch((err) => {
+      this.utils.toast({ title: '二维码库加载失败', type: 'error' });
     });
 }
 ```
@@ -1026,102 +1152,58 @@ export function someFunctionName() {
 
 ### router.push
 
-**描述**：页面路由跳转工具，用于在宜搭应用内进行页面跳转。
+**描述**：页面路由跳转工具。支持两种常见方式：1.跳转到完整 URL，2.跳转到同一应用内的表单页或自定义页。
 
-#### 参数说明
+参数说明：
 
-| 参数位置 | 参数名 | 类型 | 必填 | 说明 |
-| :------- | :----- | :--- | :--- | :--- |
-| 参数 1 | `target` | String | 是 | 跳转目标：同应用内的页面 ID（如 `FORM-XXX`）或完整 URL |
-| 参数 2 | `params` | Object | 否 | 携带的跳转参数对象，默认 `{}` |
-| 参数 3 | `newTab` | Boolean | 否 | 是否新开标签页，`true` 新开，`false` 当前页跳转，默认 `false` |
-| 参数 4 | `isExternal` | Boolean | 否 | 是否是外部网址，仅当参数 1 为完整 URL 时需要传 `true` |
+| 参数位置 | 说明                                              |
+| :------- | :------------------------------------------------ |
+| 参数 1   | 完整 URL，或同应用内页面 ID                       |
+| 参数 2   | 携带的跳转参数对象                                |
+| 参数 3   | 是否新开页面，`true` 为新开，`false` 为当前页跳转 |
+| 参数 4   | 是否是外部网址，仅在传完整 URL 时使用             |
 
-#### 使用场景与示例
-
-**场景一：跳转同应用内的表单页或自定义页（推荐）**
-
-当跳转目标与当前页面属于同一个宜搭应用时，直接传页面 ID 即可，无需手拼 URL。
+用法一：跳转完整 URL
 
 ```javascript
-// ✅ 正确：同应用内跳转，传页面 ID
-this.utils.router.push('FORM-XXX', {}, false);
-
-// ✅ 正确：带参数跳转
-this.utils.router.push('FORM-XXX', { id: '123', type: 'edit' }, false);
-
-// ✅ 正确：跳转到自定义页（PAGE-XXX）
-this.utils.router.push('PAGE-XXX', { mode: 'view' }, false);
-
-// ✅ 正确：新标签页打开
-this.utils.router.push('FORM-XXX', {}, true);
+/**
+ * 参数1：完整 url
+ * 参数2：携带跳转参数
+ * 参数3：是否新页面打开，true / false
+ * 参数4：是否是网址
+ */
+this.utils.router.push('https://yeyi...', {}, true, true);
 ```
 
-**场景二：跳转外部网址**
-
-跳转到宜搭应用外部的网址时，必须传第四个参数 `isExternal = true`。
+用法二：跳转同应用内页面
 
 ```javascript
-// ✅ 正确：跳转外部网址，必须传第四个参数 true
-this.utils.router.push('https://www.example.com', {}, false, true);
-
-// ❌ 错误：跳转外部网址但未传第四个参数，会导致跳转失败
-this.utils.router.push('https://www.example.com', {}, false);
+/**
+ * 参数1：表单页面 ID，必须是同一个应用内
+ * 参数2：携带跳转参数
+ * 参数3：是否新页面打开，true / false
+ */
+this.utils.router.push('FORM-WC96669...', {}, true);
 ```
 
-#### 最佳实践
-
-1. **同应用内跳转优先使用页面 ID**：不要手拼完整 URL，直接使用 `FORM-XXX` 或 `PAGE-XXX`，让系统自动处理路由。
-
-2. **参数传递**：需要传递参数时，通过第二个参数 `params` 对象传递，目标页面可通过 `this.state.urlParams` 获取。
-
-   ```javascript
-   // 跳转时传参
-   this.utils.router.push('FORM-XXX', { orderId: '123', action: 'edit' }, false);
-   
-   // 目标页面获取参数
-   export function didMount() {
-     const orderId = this.state.urlParams.orderId;  // '123'
-     const action = this.state.urlParams.action;    // 'edit'
-   }
-   ```
-
-3. **是否新开标签页**：
-   - 管理系统内部页面切换，优先使用 `false`（当前页跳转），避免打开过多标签页
-   - 跳转到外部系统或需要保留当前页面状态时，使用 `true`（新标签页打开）
-
-#### 常见错误
+推荐写法：
 
 ```javascript
-// ❌ 错误：跳转外部网址未传第四个参数
-this.utils.router.push('https://example.com', {}, false);
+// 同应用内跳转到后台管理页，当前页打开
+this.utils.router.push('FORM-XXX', {
+  isRenderNav: false,
+  corpid: 'dingxxxxxxxx'
+}, false);
 
-// ✅ 正确：跳转外部网址必须传 isExternal = true
+// 跳转外部网址，当前页打开
 this.utils.router.push('https://example.com', {}, false, true);
-
-// ❌ 错误：同应用内跳转却手拼了完整 URL（容易出错，不推荐）
-this.utils.router.push('https://www.aliwork.com/APP_XXX/workbench/FORM-XXX', {}, false, true);
-
-// ✅ 正确：同应用内跳转直接传页面 ID
-this.utils.router.push('FORM-XXX', {}, false);
 ```
 
-#### ⚠️ 重要提醒：禁止手拼宜搭 URL
+使用建议：
 
-**`aliwork.com` 是宜搭平台的域名，同应用内跳转永远不要手拼完整 URL！**
-
-```javascript
-// ❌ 绝对禁止：手拼宜搭 URL（包括 submission、workbench 等路径）
-this.utils.router.push('https://www.aliwork.com/APP_XXX/submission/FORM-XXX');
-this.utils.router.push('https://www.aliwork.com/APP_XXX/workbench/FORM-XXX');
-
-// ✅ 正确：直接传页面 ID，系统自动处理路由
-this.utils.router.push('FORM-XXX', {}, false);
-```
-
-**判断标准**：
-- 如果 URL 包含 `aliwork.com` → 这是宜搭应用内页面，**必须**使用页面 ID（`FORM-XXX` 或 `PAGE-XXX`）
-- 如果 URL 是其他域名（如 `example.com`）→ 这是外部网址，需要传第四个参数 `true`
+- 管理系统内部页面切换，优先使用 `false`，避免新开页面。
+- 当跳转目标是同应用内的自定义页或表单页时，优先传页面 ID，不要手拼完整 URL。
+- 当跳转目标是外部网址时，第四个参数传 `true`，明确告诉路由工具这是一个网址。
 
 ---
 

--- a/skills/yida-form-permission/SKILL.md
+++ b/skills/yida-form-permission/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: yida-form-permission
+description: 宜搭表单权限配置技能，支持查询和配置表单的字段权限（可见/隐藏/只读/可编辑）、数据权限（全部/本人/本部门/自定义）和操作权限（增删改查导出）。
+license: MIT
+compatibility:
+- opencode
+- claude-code
+metadata:
+  audience: developers
+  workflow: yida-development
+  version: 1.0.0
+  tags:
+  - yida
+  - low-code
+  - permission
+  - form-permission
+---
+
+# 宜搭表单权限配置技能
+
+## 概述
+
+本技能提供宜搭表单的权限配置功能，支持三种维度的权限控制：
+
+| 权限维度 | 说明 |
+|---------|------|
+| **字段权限** | 控制不同角色对表单字段的可见性：可见、隐藏、只读、可编辑、脱敏 |
+| **数据权限** | 控制不同角色可访问的数据范围：全部数据、本人数据、本部门数据、自定义规则 |
+| **操作权限** | 控制不同角色对表单的操作能力：新增、查看、编辑、删除、导出 |
+
+> ⚠️ **当前限制**：
+> - **权限成员**：仅支持「全部人员」（`DEFAULT`）和「管理员」（`MANAGER`）两种类型，暂不支持「权限矩阵」
+> - **数据范围**：暂不支持「自定义部门」（`CUSTOM_DEPARTMENT`）和「自定义过滤条件」（`FORMULA`/`CUSTOM`）
+> - **字段权限**：暂不支持自定义字段权限配置（接口尚未验证），如需配置请通过宜搭管理后台手动操作
+
+## 何时使用
+
+当以下场景发生时使用此技能：
+
+- 用户需要配置表单的字段级权限（如隐藏敏感字段）
+- 用户需要配置数据范围权限（如只能看自己的数据）
+- 用户需要配置操作权限（如禁止删除）
+- 用户需要查看当前表单的权限配置
+
+## 使用示例
+
+### 示例 1：查询表单权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/get-permission.js APP_XXX FORM-XXX
+```
+
+### 示例 2：保存字段权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX '[{"fieldId":"textField_xxx","behavior":"HIDDEN","roles":["member"]},{"fieldId":"numberField_xxx","behavior":"READONLY","roles":["member"]}]'
+```
+
+### 示例 3：保存数据权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX --data-permission '{"role":"member","dataRange":"SELF"}'
+```
+
+### 示例 4：保存操作权限配置
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js APP_XXX FORM-XXX --action-permission '{"role":"member","actions":{"create":true,"view":true,"edit":false,"delete":false,"export":false}}'
+```
+
+## 工具说明
+
+### 1. get-permission - 获取权限配置
+
+获取表单当前的权限配置信息。
+
+```bash
+node .claude/skills/yida-form-permission/scripts/get-permission.js <appType> <formUuid>
+```
+
+**参数**：
+
+| 参数 | 必填 | 说明 |
+| --- | --- | --- |
+| `appType` | 是 | 应用 ID，如 `APP_XXX` |
+| `formUuid` | 是 | 表单 UUID，如 `FORM-XXX` |
+
+**输出**：
+
+```json
+{
+  "success": true,
+  "permissions": {
+    "fieldPermissions": [
+      {
+        "fieldId": "textField_xxx",
+        "label": "姓名",
+        "behavior": "NORMAL",
+        "roles": ["all"]
+      }
+    ],
+    "dataPermissions": [
+      {
+        "role": "member",
+        "dataRange": "SELF"
+      }
+    ],
+    "actionPermissions": [
+      {
+        "role": "member",
+        "actions": {
+          "create": true,
+          "view": true,
+          "edit": false,
+          "delete": false,
+          "export": false
+        }
+      }
+    ]
+  }
+}
+```
+
+### 2. save-permission - 保存权限配置
+
+保存表单的权限配置。
+
+```bash
+node .claude/skills/yida-form-permission/scripts/save-permission.js <appType> <formUuid> [fieldPermissionsJson] [--data-permission <json>] [--action-permission <json>]
+```
+
+**参数**：
+
+| 参数 | 必填 | 说明 |
+| --- | --- | --- |
+| `appType` | 是 | 应用 ID |
+| `formUuid` | 是 | 表单 UUID |
+| `fieldPermissionsJson` | 否 | 字段权限 JSON 数组 |
+| `--data-permission` | 否 | 数据权限 JSON |
+| `--action-permission` | 否 | 操作权限 JSON |
+
+#### 字段权限 JSON 格式
+
+```json
+[
+  {
+    "fieldId": "textField_xxx",
+    "behavior": "HIDDEN",
+    "roles": ["member"]
+  },
+  {
+    "fieldId": "numberField_xxx",
+    "behavior": "READONLY",
+    "roles": ["member"]
+  }
+]
+```
+
+**behavior 取值**：
+
+| 值 | 说明 |
+|---|------|
+| `NORMAL` | 正常（可见可编辑） |
+| `READONLY` | 只读（可见不可编辑） |
+| `HIDDEN` | 隐藏（不可见） |
+| `MASKED` | 脱敏展示 |
+
+#### 数据权限 JSON 格式
+
+```json
+{
+  "role": "member",
+  "dataRange": "SELF",
+  "customRule": null
+}
+```
+
+**dataRange 取值**：
+
+| 值 | 说明 | 是否支持 |
+|---|------|---------|
+| `ALL` | 全部数据 | ✅ |
+| `SELF` / `ORIGINATOR` | 本人提交的数据 | ✅ |
+| `DEPARTMENT` / `ORIGINATOR_DEPARTMENT` | 本部门提交的数据 | ✅ |
+| `SAME_LEVEL_DEPARTMENT` | 同级部门提交的数据 | ✅ |
+| `SUBORDINATE_DEPARTMENT` | 下级部门提交的数据 | ✅ |
+| `FREE_LOGIN` | 免登提交的数据 | ✅ |
+| `CUSTOM_DEPARTMENT` | 自定义部门 | ❌ 暂不支持 |
+| `FORMULA` / `CUSTOM` | 自定义过滤条件 | ❌ 暂不支持 |
+
+#### 操作权限 JSON 格式
+
+```json
+{
+  "role": "member",
+  "actions": {
+    "create": true,
+    "view": true,
+    "edit": false,
+    "delete": false,
+    "export": false
+  }
+}
+```
+
+## 前置依赖
+
+- Node.js
+- 项目根目录存在 `.cache/cookies.json`（首次运行会自动触发扫码登录）
+
+## 调用流程
+
+1. 读取项目根目录的 `.cache/cookies.json` 获取登录态；若不存在则自动触发扫码登录
+2. 调用对应接口进行权限查询或保存
+3. 根据响应体 `errorCode` 自动处理异常（csrf 过期自动刷新、登录过期自动重新登录）
+4. 返回操作结果
+
+## 文件结构
+
+```
+yida-form-permission/
+├── SKILL.md                          # 本文档
+└── scripts/
+    ├── get-permission.js             # 权限配置查询脚本
+    └── save-permission.js            # 权限配置保存脚本
+```
+
+## 接口说明
+
+### getFormPermission（获取表单权限配置）
+
+- **地址**：`GET /dingtalk/web/{appType}/query/formdesign/getFormPermission.json`
+- **参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `_api` | String | 是 | `Form.getFormPermission` |
+| `formUuid` | String | 是 | 表单 UUID |
+| `_csrf_token` | String | 是 | CSRF Token |
+
+- **返回值**：包含 `fieldPermissions`、`dataPermissions`、`actionPermissions` 的权限配置对象
+
+### saveFormPermission（保存表单权限配置）
+
+- **地址**：`POST /dingtalk/web/{appType}/query/formdesign/saveFormPermission.json`
+- **参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `_api` | String | 是 | `Form.saveFormPermission` |
+| `formUuid` | String | 是 | 表单 UUID |
+| `permissionConfig` | String | 是 | 权限配置 JSON |
+| `_csrf_token` | String | 是 | CSRF Token |
+
+- **返回值**：`success: true` 表示成功
+
+## 与其他技能配合
+
+- **创建表单** → 使用 `yida-create-form-page` 技能
+- **获取表单 Schema** → 使用 `yida-get-schema` 技能（获取 fieldId）
+- **页面配置** → 使用 `yida-page-config` 技能
+- **发布页面** → 使用 `yida-publish-page` 技能
+
+## 注意事项
+
+- 配置权限前，建议先通过 `yida-get-schema` 技能获取表单的字段列表和 fieldId
+- 字段权限中的 `fieldId` 必须与表单 Schema 中的字段 ID 一致
+- 临时文件写在当前工程根目录的 `.cache` 文件夹中
+
+### 当前功能限制
+
+| 功能 | 限制说明 |
+|------|---------|
+| **权限成员** | 仅支持「全部人员」（`DEFAULT`）和「管理员」（`MANAGER`），**暂不支持「权限矩阵」** |
+| **数据范围** | **暂不支持**「自定义部门」（`CUSTOM_DEPARTMENT`）和「自定义过滤条件」（`FORMULA`/`CUSTOM`） |
+| **字段权限** | **暂不支持自定义字段权限**，如需配置请通过宜搭管理后台手动操作 |

--- a/skills/yida-form-permission/scripts/get-permission.js
+++ b/skills/yida-form-permission/scripts/get-permission.js
@@ -1,0 +1,363 @@
+const https = require("https");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+// 权限接口域名
+const PERMISSION_BASE_URL = "https://www.aliwork.com";
+
+function findProjectRoot() {
+  for (const startDir of [process.cwd(), __dirname]) {
+    let currentDir = startDir;
+    while (currentDir !== path.dirname(currentDir)) {
+      if (
+        fs.existsSync(path.join(currentDir, "README.md")) ||
+        fs.existsSync(path.join(currentDir, ".git"))
+      ) {
+        return currentDir;
+      }
+      currentDir = path.dirname(currentDir);
+    }
+  }
+  return process.cwd();
+}
+
+const PROJECT_ROOT = findProjectRoot();
+const COOKIE_FILE = path.join(PROJECT_ROOT, ".cache", "cookies.json");
+
+function findLoginScript() {
+  const candidates = [
+    path.join(PROJECT_ROOT, ".claude", "skills", "yida-login", "scripts", "login.py"),
+    path.join(PROJECT_ROOT, "skills", "yida-login", "scripts", "login.py"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return candidates[0];
+}
+
+const LOGIN_SCRIPT = findLoginScript();
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error("用法: node get-permission.js <appType> <formUuid>");
+    console.error('示例: node .claude/skills/yida-form-permission/scripts/get-permission.js "APP_XXX" "FORM-XXX"');
+    process.exit(1);
+  }
+  return {
+    appType: args[0],
+    formUuid: args[1],
+  };
+}
+
+function extractInfoFromCookies(cookies) {
+  let csrfToken = null;
+  let corpId = null;
+  for (const cookie of cookies) {
+    if (cookie.name === "tianshu_csrf_token") {
+      csrfToken = cookie.value;
+    } else if (cookie.name === "tianshu_corp_user") {
+      const lastUnderscore = cookie.value.lastIndexOf("_");
+      if (lastUnderscore > 0) {
+        corpId = cookie.value.slice(0, lastUnderscore);
+      }
+    }
+  }
+  return { csrfToken, corpId };
+}
+
+function loadCookieData() {
+  if (!fs.existsSync(COOKIE_FILE)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(COOKIE_FILE, "utf-8").trim();
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    let cookieData;
+    if (Array.isArray(parsed)) {
+      cookieData = { cookies: parsed };
+    } else {
+      cookieData = parsed;
+    }
+    if (cookieData.cookies && cookieData.cookies.length > 0) {
+      const { csrfToken, corpId } = extractInfoFromCookies(cookieData.cookies);
+      if (csrfToken) cookieData.csrf_token = csrfToken;
+      if (corpId) cookieData.corp_id = corpId;
+    }
+    return cookieData;
+  } catch {
+    return null;
+  }
+}
+
+function triggerLogin() {
+  console.error("\n🔐 登录态失效，正在调用 login.py 重新登录...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}"`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 180_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const loginResult = JSON.parse(jsonLine);
+    if (!loginResult.cookies) throw new Error("登录结果缺少 cookies");
+    return loginResult;
+  } catch (err) {
+    console.error(`  ❌ 解析登录结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function refreshCsrfToken() {
+  console.error("\n🔄 csrf_token 已过期，正在刷新...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}" --refresh-csrf`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 60_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const result = JSON.parse(jsonLine);
+    if (!result.csrf_token || !result.cookies)
+      throw new Error("刷新结果缺少 csrf_token 或 cookies");
+    return result;
+  } catch (err) {
+    console.error(`  ❌ 解析刷新结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function isLoginExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    (responseJson.errorCode === "307" || responseJson.errorCode === "302")
+  );
+}
+
+function isCsrfTokenExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    responseJson.errorCode === "TIANSHU_000030"
+  );
+}
+
+/**
+ * 获取权限组列表
+ * 接口：GET /{appType}/permission/manage/listPermitPackages.json
+ * 域名：yidalogin.aliwork.com
+ */
+function listPermitPackages(cookies, appType, formUuid, csrfToken) {
+  const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  const parsedUrl = new URL(PERMISSION_BASE_URL);
+  const isHttps = parsedUrl.protocol === "https:";
+  const requestModule = isHttps ? https : http;
+
+  const queryParams = new URLSearchParams({
+    _api: "Permission.getPermitGroupList",
+    _mock: "false",
+    _csrf_token: csrfToken,
+    _locale_time_zone_offset: "28800000",
+    formUuid: formUuid,
+    packageName: "",
+    packageType: "FORM_PACKAGE_VIEW",
+    pageIndex: "1",
+    pageSize: "20",
+    appType: appType,
+    _stamp: String(Date.now()),
+  });
+
+  const requestPath = `/${appType}/permission/manage/listPermitPackages.json?${queryParams.toString()}`;
+
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "GET",
+      headers: {
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        "X-Requested-With": "XMLHttpRequest",
+        Referer: `${PERMISSION_BASE_URL}/${appType}/admin/${formUuid}/settings/permission`,
+      },
+      timeout: 30000,
+    };
+
+    const req = requestModule.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        console.error(`  HTTP 状态码: ${res.statusCode}`);
+        try {
+          const parsed = JSON.parse(data);
+          if (isLoginExpired(parsed)) {
+            resolve({ __needLogin: true });
+            return;
+          }
+          if (isCsrfTokenExpired(parsed)) {
+            resolve({ __csrfExpired: true });
+            return;
+          }
+          resolve(parsed);
+        } catch {
+          console.error(`  响应内容: ${data.substring(0, 500)}`);
+          resolve({ success: false, errorMsg: "响应非 JSON" });
+        }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("请求超时")); });
+    req.end();
+  });
+}
+
+/**
+ * 将权限组列表格式化为可读的权限配置摘要
+ */
+function formatPermissions(packages) {
+  return packages.map((pkg) => {
+    const packageName = pkg.packageName
+      ? (pkg.packageName.zh_CN || pkg.packageName.en_US || JSON.stringify(pkg.packageName))
+      : "未命名";
+    const description = pkg.description
+      ? (pkg.description.zh_CN || pkg.description.en_US || "")
+      : "";
+
+    // 解析权限成员
+    const roleMembers = (pkg.roleMembers || []).map((rm) => ({
+      roleType: rm.roleType,
+      label: rm.label,
+      roleValue: rm.roleValue,
+    }));
+
+    // 解析数据权限
+    let dataPermit = {};
+    if (pkg.dataPermit) {
+      try {
+        dataPermit = typeof pkg.dataPermit === "string" ? JSON.parse(pkg.dataPermit) : pkg.dataPermit;
+      } catch { dataPermit = {}; }
+    }
+
+    // 解析操作权限
+    let operatePermit = {};
+    if (pkg.operatePermit) {
+      try {
+        operatePermit = typeof pkg.operatePermit === "string" ? JSON.parse(pkg.operatePermit) : pkg.operatePermit;
+      } catch { operatePermit = {}; }
+    }
+
+    // 解析字段权限
+    let fieldPermit = {};
+    if (pkg.fieldPermit) {
+      try {
+        fieldPermit = typeof pkg.fieldPermit === "string" ? JSON.parse(pkg.fieldPermit) : pkg.fieldPermit;
+      } catch { fieldPermit = {}; }
+    }
+
+    return {
+      packageUuid: pkg.packageUuid,
+      packageName,
+      description,
+      packageType: pkg.packageType,
+      roleMembers,
+      dataPermit,
+      operatePermit,
+      fieldPermit,
+    };
+  });
+}
+
+async function main() {
+  const { appType, formUuid } = parseArgs();
+
+  console.error("=".repeat(50));
+  console.error("  get-permission - 宜搭表单权限配置查询工具");
+  console.error("=".repeat(50));
+  console.error(`\n  应用 ID:   ${appType}`);
+  console.error(`  表单 UUID: ${formUuid}`);
+  console.error(`  接口域名:  ${PERMISSION_BASE_URL}`);
+
+  console.error("\n🔑 Step 1: 读取登录态");
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error("  ⚠️  未找到本地登录态，触发登录...");
+    cookieData = triggerLogin();
+  }
+  let { cookies } = cookieData;
+  let csrfToken = cookieData.csrf_token;
+  console.error("  ✅ 登录态已就绪");
+
+  console.error("\n📋 Step 2: 查询权限组列表");
+  console.error("  发送 listPermitPackages 请求...");
+
+  let result = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+
+  // 处理 csrf_token 过期
+  if (result && result.__csrfExpired) {
+    cookieData = refreshCsrfToken();
+    csrfToken = cookieData.csrf_token;
+    cookies = cookieData.cookies;
+    console.error("  🔄 重新发送请求（csrf_token 已刷新）...");
+    result = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+  }
+
+  // 处理登录过期
+  if (result && result.__needLogin) {
+    cookieData = triggerLogin();
+    csrfToken = cookieData.csrf_token;
+    cookies = cookieData.cookies;
+    console.error("  🔄 重新发送请求（已重新登录）...");
+    result = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+  }
+
+  console.error("\n" + "=".repeat(50));
+  if (result && !result.__needLogin && !result.__csrfExpired) {
+    if (result.success) {
+      const packages = (result.content && result.content.formPermit) || [];
+      console.error(`  ✅ 权限配置查询成功！共 ${packages.length} 个权限组`);
+      console.error("=".repeat(50));
+
+      const formattedPermissions = formatPermissions(packages);
+      console.log(JSON.stringify({
+        success: true,
+        totalPackages: packages.length,
+        permissions: formattedPermissions,
+        message: "权限配置查询成功",
+      }, null, 2));
+    } else {
+      console.error(`  ❌ 查询失败: ${result.errorMsg || "未知错误"}`);
+      console.error("=".repeat(50));
+      console.log(JSON.stringify({
+        success: false,
+        message: result.errorMsg || "查询失败",
+        errorCode: result.errorCode,
+      }, null, 2));
+    }
+  } else {
+    console.error("  ❌ 请求失败");
+    console.error("=".repeat(50));
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(`\n❌ 查询异常: ${error.message}`);
+  process.exit(1);
+});

--- a/skills/yida-form-permission/scripts/save-permission.js
+++ b/skills/yida-form-permission/scripts/save-permission.js
@@ -1,0 +1,709 @@
+const https = require("https");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const querystring = require("querystring");
+const { execSync } = require("child_process");
+
+const CONFIG_PATH = path.resolve(findProjectRoot(), "config.json");
+
+function findProjectRoot() {
+  for (const startDir of [process.cwd(), __dirname]) {
+    let currentDir = startDir;
+    while (currentDir !== path.dirname(currentDir)) {
+      if (
+        fs.existsSync(path.join(currentDir, "README.md")) ||
+        fs.existsSync(path.join(currentDir, ".git"))
+      ) {
+        return currentDir;
+      }
+      currentDir = path.dirname(currentDir);
+    }
+  }
+  return process.cwd();
+}
+
+const CONFIG = fs.existsSync(CONFIG_PATH)
+  ? JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"))
+  : {};
+const DEFAULT_BASE_URL = CONFIG.defaultBaseUrl || "https://www.aliwork.com";
+// 权限接口域名
+const PERMISSION_BASE_URL = "https://www.aliwork.com";
+const PROJECT_ROOT = findProjectRoot();
+const COOKIE_FILE = path.join(PROJECT_ROOT, ".cache", "cookies.json");
+
+function findLoginScript() {
+  const candidates = [
+    path.join(PROJECT_ROOT, ".claude", "skills", "yida-login", "scripts", "login.py"),
+    path.join(PROJECT_ROOT, "skills", "yida-login", "scripts", "login.py"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return candidates[0];
+}
+
+const LOGIN_SCRIPT = findLoginScript();
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(
+      "用法: node save-permission.js <appType> <formUuid> [fieldPermissionsJson] [--data-permission <json>] [--action-permission <json>]"
+    );
+    console.error("");
+    console.error("示例:");
+    console.error(
+      '  字段权限: node save-permission.js APP_XXX FORM-XXX \'[{"fieldId":"textField_xxx","behavior":"HIDDEN","roles":["member"]}]\''
+    );
+    console.error(
+      '  数据权限: node save-permission.js APP_XXX FORM-XXX --data-permission \'{"role":"member","dataRange":"SELF"}\''
+    );
+    console.error(
+      '  操作权限: node save-permission.js APP_XXX FORM-XXX --action-permission \'{"role":"DEFAULT","operations":{"OPERATE_VIEW":true,"OPERATE_EDIT":false,"OPERATE_DELETE":false}}\''
+    );
+    process.exit(1);
+  }
+
+  const parsed = {
+    appType: args[0],
+    formUuid: args[1],
+    fieldPermissions: null,
+    dataPermission: null,
+    actionPermission: null,
+  };
+
+  let index = 2;
+  while (index < args.length) {
+    if (args[index] === "--data-permission" && args[index + 1]) {
+      parsed.dataPermission = parseJsonArg(args[index + 1], "data-permission");
+      index += 2;
+    } else if (args[index] === "--action-permission" && args[index + 1]) {
+      parsed.actionPermission = parseJsonArg(args[index + 1], "action-permission");
+      index += 2;
+    } else if (!parsed.fieldPermissions) {
+      parsed.fieldPermissions = parseJsonArg(args[index], "fieldPermissions");
+      index += 1;
+    } else {
+      index += 1;
+    }
+  }
+
+  if (!parsed.fieldPermissions && !parsed.dataPermission && !parsed.actionPermission) {
+    console.error("❌ 至少需要提供一种权限配置（字段权限/数据权限/操作权限）");
+    process.exit(1);
+  }
+
+  return parsed;
+}
+
+function parseJsonArg(jsonStr, paramName) {
+  if (fs.existsSync(jsonStr)) {
+    try {
+      return JSON.parse(fs.readFileSync(jsonStr, "utf-8"));
+    } catch (err) {
+      console.error(`❌ 解析 ${paramName} 文件失败: ${err.message}`);
+      process.exit(1);
+    }
+  }
+  try {
+    return JSON.parse(jsonStr);
+  } catch (err) {
+    console.error(`❌ 解析 ${paramName} JSON 失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function validateFieldPermissions(fieldPermissions) {
+  if (!Array.isArray(fieldPermissions)) {
+    throw new Error("字段权限必须是数组格式");
+  }
+  const validBehaviors = ["NORMAL", "READONLY", "HIDDEN", "MASKED"];
+  for (const permission of fieldPermissions) {
+    if (!permission.fieldId) {
+      throw new Error("每个字段权限必须包含 fieldId");
+    }
+    if (permission.behavior && !validBehaviors.includes(permission.behavior)) {
+      throw new Error(
+        `无效的 behavior: ${permission.behavior}，有效值: ${validBehaviors.join(", ")}`
+      );
+    }
+  }
+}
+
+function validateDataPermission(dataPermission) {
+  const validRanges = [
+    // 用户友好别名
+    "ALL", "SELF", "DEPARTMENT", "CUSTOM",
+    // 接口原始值
+    "ORIGINATOR", "ORIGINATOR_DEPARTMENT",
+    "SAME_LEVEL_DEPARTMENT", "SUBORDINATE_DEPARTMENT",
+    "FREE_LOGIN", "CUSTOM_DEPARTMENT", "FORMULA",
+  ];
+  if (dataPermission.dataRange && !validRanges.includes(dataPermission.dataRange)) {
+    throw new Error(
+      `无效的 dataRange: ${dataPermission.dataRange}，有效值: ${validRanges.join(", ")}`
+    );
+  }
+}
+
+// 所有支持的操作权限 key（来自宜搭接口实际值）
+const VALID_OPERATE_KEYS = [
+  "OPERATE_VIEW",              // 查看
+  "OPERATE_EDIT",              // 编辑
+  "OPERATE_DELETE",            // 删除
+  "OPERATE_HISTORY",           // 变更记录
+  "OPERATE_COMMENT",           // 评论
+  "OPERATE_PRINT",             // 打印
+  "OPERATE_BATCH_IMPORT",      // 批量导入
+  "OPERATE_BATCH_EXPORT",      // 批量导出
+  "OPERATE_BATCH_EDIT",        // 批量修改
+  "OPERATE_BATCH_DELETE",      // 批量删除
+  "OPERATE_BATCH_PRINT",       // 批量打印
+  "OPERATE_BATCH_DOWNLOAD",    // 批量下载文件
+  "OPERATE_BATCH_DOWNLOAD_QRCODE", // 批量下载二维码
+  "OPERATE_CREATE",            // 新增（提交）
+];
+
+function validateActionPermission(actionPermission) {
+  if (!actionPermission.operations || typeof actionPermission.operations !== "object") {
+    throw new Error(
+      "操作权限必须包含 operations 对象，格式为 {\"OPERATE_VIEW\": true, \"OPERATE_EDIT\": false, ...}"
+    );
+  }
+  for (const key of Object.keys(actionPermission.operations)) {
+    if (!VALID_OPERATE_KEYS.includes(key)) {
+      throw new Error(
+        `无效的操作权限 key: ${key}，有效值: ${VALID_OPERATE_KEYS.join(", ")}`
+      );
+    }
+  }
+}
+
+function extractInfoFromCookies(cookies) {
+  let csrfToken = null;
+  let corpId = null;
+  for (const cookie of cookies) {
+    if (cookie.name === "tianshu_csrf_token") {
+      csrfToken = cookie.value;
+    } else if (cookie.name === "tianshu_corp_user") {
+      const lastUnderscore = cookie.value.lastIndexOf("_");
+      if (lastUnderscore > 0) {
+        corpId = cookie.value.slice(0, lastUnderscore);
+      }
+    }
+  }
+  return { csrfToken, corpId };
+}
+
+function loadCookieData() {
+  if (!fs.existsSync(COOKIE_FILE)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(COOKIE_FILE, "utf-8").trim();
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    let cookieData;
+    if (Array.isArray(parsed)) {
+      cookieData = { cookies: parsed, base_url: DEFAULT_BASE_URL };
+    } else {
+      cookieData = parsed;
+    }
+    if (cookieData.cookies && cookieData.cookies.length > 0) {
+      const { csrfToken, corpId } = extractInfoFromCookies(cookieData.cookies);
+      if (csrfToken) cookieData.csrf_token = csrfToken;
+      if (corpId) cookieData.corp_id = corpId;
+    }
+    return cookieData;
+  } catch {
+    return null;
+  }
+}
+
+function triggerLogin() {
+  console.error("\n🔐 登录态失效，正在调用 login.py 重新登录...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}"`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 180_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const loginResult = JSON.parse(jsonLine);
+    if (!loginResult.cookies) throw new Error("登录结果缺少 cookies");
+    return loginResult;
+  } catch (err) {
+    console.error(`  ❌ 解析登录结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function resolveBaseUrl(cookieData) {
+  return ((cookieData && cookieData.base_url) || DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function isLoginExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    (responseJson.errorCode === "307" || responseJson.errorCode === "302")
+  );
+}
+
+function isCsrfTokenExpired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    responseJson.errorCode === "TIANSHU_000030"
+  );
+}
+
+function refreshCsrfToken() {
+  console.error("\n🔄 csrf_token 已过期，正在刷新...\n");
+  if (!fs.existsSync(LOGIN_SCRIPT)) {
+    console.error(`  ❌ 登录脚本不存在: ${LOGIN_SCRIPT}`);
+    process.exit(1);
+  }
+  const stdout = execSync(`python3 "${LOGIN_SCRIPT}" --refresh-csrf`, {
+    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "inherit"],
+    timeout: 60_000,
+  });
+  const lines = stdout.trim().split("\n");
+  const jsonLine = lines[lines.length - 1];
+  try {
+    const result = JSON.parse(jsonLine);
+    if (!result.csrf_token || !result.cookies)
+      throw new Error("刷新结果缺少 csrf_token 或 cookies");
+    return result;
+  } catch (err) {
+    console.error(`  ❌ 解析刷新结果失败: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function sendPostRequest(baseUrl, cookies, requestPath, postData) {
+  return new Promise((resolve, reject) => {
+    const cookieHeader = cookies
+      .map((cookie) => `${cookie.name}=${cookie.value}`)
+      .join("; ");
+
+    const parsedUrl = new URL(baseUrl);
+    const isHttps = parsedUrl.protocol === "https:";
+    const requestModule = isHttps ? https : http;
+
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "POST",
+      headers: {
+        Origin: baseUrl,
+        Referer: baseUrl + "/",
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "x-requested-with": "XMLHttpRequest",
+      },
+      timeout: 30000,
+    };
+
+    const request = requestModule.request(requestOptions, (response) => {
+      let responseData = "";
+      response.on("data", (chunk) => {
+        responseData += chunk;
+      });
+      response.on("end", () => {
+        console.error(`  HTTP 状态码: ${response.statusCode}`);
+        let parsed;
+        try {
+          parsed = JSON.parse(responseData);
+        } catch (parseError) {
+          console.error(`  响应内容: ${responseData.substring(0, 500)}`);
+          resolve({
+            success: false,
+            errorMsg: `HTTP ${response.statusCode}: 响应非 JSON`,
+          });
+          return;
+        }
+        if (isLoginExpired(parsed)) {
+          console.error(`  检测到登录过期: ${parsed.errorMsg}`);
+          resolve({ __needLogin: true });
+          return;
+        }
+        if (isCsrfTokenExpired(parsed)) {
+          console.error(`  检测到 csrf_token 过期: ${parsed.errorMsg}`);
+          resolve({ __csrfExpired: true });
+          return;
+        }
+        resolve(parsed);
+      });
+    });
+
+    request.on("timeout", () => {
+      console.error("  ❌ 请求超时");
+      request.destroy();
+      reject(new Error("请求超时"));
+    });
+
+    request.on("error", (requestError) => {
+      reject(requestError);
+    });
+
+    request.write(postData);
+    request.end();
+  });
+}
+
+// 数据权限范围映射：用户友好的 dataRange 值 -> 接口实际使用的 type 值
+// 同时也支持直接传入接口原始值（如 ORIGINATOR_DEPARTMENT）
+const DATA_RANGE_TO_PERMIT_TYPE = {
+  // 用户友好别名
+  ALL: "ALL",                                       // 全部数据
+  SELF: "ORIGINATOR",                               // 本人提交（别名）
+  DEPARTMENT: "ORIGINATOR_DEPARTMENT",              // 本部门提交（别名）
+  CUSTOM: "FORMULA",                                // 自定义过滤条件（别名）
+  // 接口原始值（直接透传）
+  ORIGINATOR: "ORIGINATOR",                         // 本人提交
+  ORIGINATOR_DEPARTMENT: "ORIGINATOR_DEPARTMENT",   // 本部门提交
+  SAME_LEVEL_DEPARTMENT: "SAME_LEVEL_DEPARTMENT",   // 同级部门提交
+  SUBORDINATE_DEPARTMENT: "SUBORDINATE_DEPARTMENT", // 下级部门提交
+  FREE_LOGIN: "FREE_LOGIN",                         // 免登提交
+  CUSTOM_DEPARTMENT: "CUSTOM_DEPARTMENT",           // 自定义部门
+  FORMULA: "FORMULA",                               // 自定义过滤条件
+};
+
+function buildPermissionConfig(fieldPermissions, dataPermission, actionPermission) {
+  const config = {};
+
+  if (fieldPermissions) {
+    config.fieldPermissions = fieldPermissions.map((permission) => ({
+      fieldId: permission.fieldId,
+      behavior: permission.behavior || "NORMAL",
+      roles: permission.roles || ["all"],
+    }));
+  }
+
+  if (dataPermission) {
+    config.dataPermissions = [
+      {
+        role: dataPermission.role || "member",
+        dataRange: dataPermission.dataRange || "ALL",
+        customRule: dataPermission.customRule || null,
+      },
+    ];
+  }
+
+  if (actionPermission) {
+    config.actionPermissions = [
+      {
+        role: actionPermission.role || "member",
+        actions: {
+          create: actionPermission.actions.create !== false,
+          view: actionPermission.actions.view !== false,
+          edit: actionPermission.actions.edit !== false,
+          delete: actionPermission.actions.delete !== false,
+          export: actionPermission.actions.export !== false,
+        },
+      },
+    ];
+  }
+
+  return config;
+}
+
+/**
+ * 获取权限组列表
+ * 接口：GET /{appType}/permission/manage/listPermitPackages.json
+ */
+async function listPermitPackages(cookies, appType, formUuid, csrfToken) {
+  const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  const parsedUrl = new URL(PERMISSION_BASE_URL);
+  const isHttps = parsedUrl.protocol === "https:";
+  const requestModule = isHttps ? https : http;
+
+  const queryParams = new URLSearchParams({
+    _api: "Permission.getPermitGroupList",
+    _mock: "false",
+    _csrf_token: csrfToken,
+    _locale_time_zone_offset: "28800000",
+    formUuid: formUuid,
+    packageName: "",
+    packageType: "FORM_PACKAGE_VIEW",
+    pageIndex: "1",
+    pageSize: "20",
+    appType: appType,
+    _stamp: String(Date.now()),
+  });
+
+  const requestPath = `/${appType}/permission/manage/listPermitPackages.json?${queryParams.toString()}`;
+
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "GET",
+      headers: {
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        "X-Requested-With": "XMLHttpRequest",
+        Referer: `${PERMISSION_BASE_URL}/${appType}/admin/${formUuid}/settings/permission`,
+      },
+      timeout: 30000,
+    };
+
+    const req = requestModule.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch {
+          resolve({ success: false, errorMsg: "响应非 JSON" });
+        }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("请求超时")); });
+    req.end();
+  });
+}
+
+/**
+ * 保存单个权限组
+ * 接口：POST /{appType}/permission/manage/saveOrUpdatePermit.json
+ */
+async function savePermitPackage(cookies, appType, formUuid, csrfToken, permitPackage) {
+  const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  const parsedUrl = new URL(PERMISSION_BASE_URL);
+  const isHttps = parsedUrl.protocol === "https:";
+  const requestModule = isHttps ? https : http;
+
+  const requestPath = `/${appType}/permission/manage/saveOrUpdatePermit.json?_api=Permission.saveOrUpdatePermitGroup&_mock=false&_stamp=${Date.now()}`;
+
+  const postParams = {
+    _csrf_token: csrfToken,
+    _locale_time_zone_offset: "28800000",
+    formUuid: formUuid,
+    packageType: permitPackage.packageType || "FORM_PACKAGE_VIEW",
+    packageName: JSON.stringify(permitPackage.packageName),
+    description: JSON.stringify(permitPackage.description),
+    roleData: JSON.stringify({
+      include: (permitPackage.roleMembers || []).map((rm) => {
+        // roleValue 可能是字符串（如 "ALL"）或数组（如 [{key: "xxx"}]）
+        let roleValue;
+        if (typeof rm.roleValue === "string") {
+          roleValue = rm.roleValue || "ALL";
+        } else if (Array.isArray(rm.roleValue) && rm.roleValue.length > 0) {
+          roleValue = rm.roleValue.map((rv) => rv.key).join(",");
+        } else {
+          roleValue = "ALL";
+        }
+        return { label: rm.label, roleType: rm.roleType, roleValue };
+      }),
+    }),
+    dataPermit: permitPackage.dataPermit,
+    operatePermit: permitPackage.operatePermit,
+    customButtonPermit: permitPackage.customButtonPermit || "[]",
+    fieldPermit: permitPackage.fieldPermit,
+    packageUuid: permitPackage.packageUuid,
+    viewData: permitPackage.viewData,
+  };
+
+  const postData = querystring.stringify(postParams);
+
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: requestPath,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": Buffer.byteLength(postData),
+        Cookie: cookieHeader,
+        Accept: "application/json, text/json",
+        Origin: PERMISSION_BASE_URL,
+        Referer: `${PERMISSION_BASE_URL}/${appType}/admin/${formUuid}/settings/permission`,
+        "X-Requested-With": "XMLHttpRequest",
+      },
+      timeout: 30000,
+    };
+
+    const req = requestModule.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch {
+          resolve({ success: false, errorMsg: "响应非 JSON" });
+        }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("请求超时")); });
+    req.write(postData);
+    req.end();
+  });
+}
+
+async function main() {
+  const { appType, formUuid, fieldPermissions, dataPermission, actionPermission } =
+    parseArgs();
+
+  console.error("=".repeat(50));
+  console.error("  save-permission - 宜搭表单权限配置保存工具");
+  console.error("=".repeat(50));
+  console.error(`\n  应用 ID:   ${appType}`);
+  console.error(`  表单 UUID: ${formUuid}`);
+
+  console.error("\n📋 Step 0: 验证参数");
+  try {
+    if (fieldPermissions) {
+      validateFieldPermissions(fieldPermissions);
+      console.error(`  ✅ 字段权限验证通过（${fieldPermissions.length} 条规则）`);
+    }
+    if (dataPermission) {
+      validateDataPermission(dataPermission);
+      console.error(`  ✅ 数据权限验证通过（${dataPermission.dataRange || "ALL"}）`);
+    }
+    if (actionPermission) {
+      validateActionPermission(actionPermission);
+      console.error("  ✅ 操作权限验证通过");
+    }
+  } catch (err) {
+    console.error(`  ❌ 参数验证失败: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.error("\n🔑 Step 1: 读取登录态");
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error("  ⚠️  未找到本地登录态，触发登录...");
+    cookieData = triggerLogin();
+  }
+  let { cookies } = cookieData;
+  let csrfToken = cookieData.csrf_token;
+  console.error(`  ✅ 登录态已就绪（接口域名: ${PERMISSION_BASE_URL}）`);
+
+  // 数据权限和操作权限都走新接口（先获取权限组列表，再逐个更新）
+  if (dataPermission || actionPermission) {
+    console.error("\n📋 Step 2: 获取当前权限组列表");
+    const listResult = await listPermitPackages(cookies, appType, formUuid, csrfToken);
+
+    if (!listResult.success) {
+      console.error(`  ❌ 获取权限组失败: ${listResult.errorMsg}`);
+      process.exit(1);
+    }
+
+    const packages = listResult.content && listResult.content.formPermit;
+    if (!packages || packages.length === 0) {
+      console.error("  ⚠️  未找到任何权限组");
+      process.exit(1);
+    }
+    console.error(`  ✅ 获取到 ${packages.length} 个权限组`);
+
+    // 根据 role 筛选要更新的权限组
+    const targetRole = (dataPermission || actionPermission).role || "DEFAULT";
+    const packagesToUpdate = packages.filter((pkg) => {
+      if (targetRole === "DEFAULT") {
+        return pkg.roleMembers && pkg.roleMembers.some((rm) => rm.roleType === "DEFAULT");
+      }
+      if (targetRole === "MANAGER") {
+        return pkg.roleMembers && pkg.roleMembers.some((rm) => rm.roleType === "MANAGER");
+      }
+      return true;
+    });
+
+    if (packagesToUpdate.length === 0) {
+      console.error(`  ⚠️  未找到匹配角色 "${targetRole}" 的权限组`);
+      process.exit(1);
+    }
+
+    console.error(`  将更新 ${packagesToUpdate.length} 个权限组`);
+
+    // 准备数据权限的 permitType
+    let permitType = null;
+    if (dataPermission) {
+      permitType = DATA_RANGE_TO_PERMIT_TYPE[dataPermission.dataRange] || dataPermission.dataRange;
+      console.error(`\n💾 Step 3: 更新权限组（数据权限: ${dataPermission.dataRange} → ${permitType}${actionPermission ? "，操作权限: 同步更新" : ""}）`);
+    } else {
+      console.error(`\n💾 Step 3: 更新权限组操作权限`);
+    }
+
+    let allSuccess = true;
+    for (const pkg of packagesToUpdate) {
+      const pkgName = pkg.packageName && (pkg.packageName.zh_CN || pkg.packageName.en_US);
+      console.error(`  → 更新权限组: ${pkgName} (${pkg.packageUuid})`);
+
+      const updatedPkg = { ...pkg };
+
+      // 更新数据权限
+      if (dataPermission) {
+        updatedPkg.dataPermit = JSON.stringify({ rule: [{ type: permitType, value: "y" }] });
+      }
+
+      // 更新操作权限：将 {OPERATE_VIEW: true, OPERATE_EDIT: false} 转为 {"OPERATE_VIEW":"y"} 格式
+      if (actionPermission) {
+        const currentOperatePermit = pkg.operatePermit
+          ? (typeof pkg.operatePermit === "string" ? JSON.parse(pkg.operatePermit) : pkg.operatePermit)
+          : {};
+        const newOperatePermit = { ...currentOperatePermit };
+        for (const [key, enabled] of Object.entries(actionPermission.operations)) {
+          if (enabled) {
+            newOperatePermit[key] = "y";
+          } else {
+            delete newOperatePermit[key];
+          }
+        }
+        updatedPkg.operatePermit = JSON.stringify(newOperatePermit);
+      }
+
+      const saveResult = await savePermitPackage(cookies, appType, formUuid, csrfToken, updatedPkg);
+
+      if (saveResult && saveResult.success) {
+        console.error(`    ✅ 更新成功`);
+      } else {
+        console.error(`    ❌ 更新失败: ${saveResult && saveResult.errorMsg}`);
+        allSuccess = false;
+      }
+    }
+
+    console.error("\n" + "=".repeat(50));
+    if (allSuccess) {
+      console.error("  ✅ 权限配置保存成功！");
+      console.error("=".repeat(50));
+      const summary = {};
+      if (dataPermission) summary.dataPermission = `数据范围: ${dataPermission.dataRange}`;
+      if (actionPermission) summary.actionPermission = `操作权限: ${Object.keys(actionPermission.operations).join(", ")}`;
+      console.log(JSON.stringify({ success: true, summary, message: "权限配置已保存" }, null, 2));
+    } else {
+      console.error("  ❌ 部分权限组更新失败");
+      console.error("=".repeat(50));
+      process.exit(1);
+    }
+    return;
+  }
+
+  // 字段权限暂不支持（原接口已失效，需要进一步探索）
+  if (fieldPermissions) {
+    console.error("\n⚠️  注意：字段权限的配置接口尚未验证，当前仅支持数据权限和操作权限配置。");
+    console.error("  如需配置字段权限，请通过宜搭管理后台手动操作。");
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(`\n❌ 保存异常: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## 关联 Issue

close openyida/openyida#111

## 变更内容

### `skills/yida-custom-page/reference/yida-api.md`

全面扩充 `loadScript` 章节：
- 新增「外部 JS 库仓库地址」说明，列出 ECharts、moment.js、QRCode 等常用库的 `g.alicdn.com/code/lib` 地址
- 新增「Combo 组合加载」原理和语法格式说明（`??` 分隔符）
- 新增 5 个完整示例：单库加载、多库链式加载、Combo 组合加载、防重复加载、QRCode 生成
- 所有示例均包含 `.catch()` 错误处理

### `skills/yida-custom-page/SKILL.md`

编码注意事项新增第 3 条「外部 JS 库引入」：
- 说明宜搭不支持直接引用外部 CDN 的限制
- 覆盖四种加载模式：单库、链式、Combo（推荐）、防重复加载
- 每种模式附带完整可运行的代码示例
- 指引到 `yida-api.md` 查看完整常用库地址列表